### PR TITLE
chore: bump version to 0.6.13 for npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-mcp-server",
-  "version": "0.1.1",
+  "version": "0.6.13",
   "description": "A dynamic API framework with easy MCP (Model Context Protocol) integration for AI models",
   "main": "index.js",
   "exports": {
@@ -50,7 +50,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/easynet-world/7134-easy-mcp-server.git"
+    "url": "git+https://github.com/easynet-world/7134-easy-mcp-server.git"
   },
   "homepage": "https://github.com/easynet-world/7134-easy-mcp-server#readme",
   "bugs": {


### PR DESCRIPTION
## Changes Made

- Updated package.json version from 0.1.1 to 0.6.13
- Fixed npm package.json warnings using 'npm pkg fix'
- Successfully published easy-mcp-server@0.6.13 to npm registry

## Summary
This PR aligns the package.json version with the GitHub release version (v0.6.13) and resolves the npm publish issues. The package has been successfully published to npm with the correct version.

## Technical Details
- Version bump: 0.1.1 → 0.6.13
- npm publish successful to https://registry.npmjs.org/
- Package size: 18.5 kB (tarball), 78.6 kB (unpacked)
- All 24 files included in the package