### PR TITLE
test: fix version assertion in OpenAPIGenerator test

### DIFF
--- a/__tests__/core-modules.test.js
+++ b/__tests__/core-modules.test.js
@@ -102,7 +102,7 @@ describe('Core Modules', () => {
       const info = generator.generateInfo();
     
       expect(info.title).toBe('Easy MCP Framework');
-      expect(info.version).toBe('0.1.1');
+      expect(info.version).toBe('0.6.13');
       expect(info.description).toContain('MCP');
       expect(info.description).toContain('AI models');
     });


### PR DESCRIPTION
## Changes Made

- Updated test assertion in 
- Changed expected version from '0.1.1' to '0.6.13'
- Aligns with the updated package.json version

## Summary
This PR fixes the failing test that was expecting the old version number. The test now correctly expects version 0.6.13, which matches the current package.json version.

## Test Results
✅ All tests now pass successfully:
- Test Suites: 5 passed, 5 total
- Tests: 44 passed, 44 total
- No failures or errors

## Technical Details
The OpenAPIGenerator.readInfo() method reads the version from package.json, so when we updated the package version, the test needed to be updated accordingly.