### PR TITLE
docs: add MCP Server URL http://localhost:3001 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ npm start
 ## **🤖 MCP (Model Context Protocol)**
 MCP enables AI models to discover and use your functions as tools. When you write a function, it automatically becomes available to AI assistants like ChatGPT, Claude, or any MCP-compatible AI model.
 
+**Connection Details:**
+- **MCP Server URL**: `http://localhost:3001`
+- **Port**: 3001 (separate from the main API server on port 3000)
+
 **Benefits:**
 - **AI Integration** - Make your APIs accessible to AI models
 - **Natural Language** - AI can understand and use your functions


### PR DESCRIPTION
## Changes Made

- Added MCP Server connection details to the README
- **MCP Server URL**: 
- **Port**: 3001 (separate from the main API server on port 3000)

## Summary
This change adds the important MCP Server connection information that users need to connect their MCP clients to the server. The MCP server runs on port 3001, separate from the main REST API server on port 3000.

## Technical Details
- MCP Server: HTTP endpoint at localhost:3001
- Main API Server: HTTP endpoint at localhost:3000
- Clear separation of services for better understanding

This will trigger a new patch release automatically.