### PR TITLE
docs: add Streamable HTTP connection type for MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ MCP enables AI models to discover and use your functions as tools. When you writ
 
 **Connection Details:**
 - **MCP Server URL**: `http://localhost:3001`
+- **Connection Type**: Use **Streamable HTTP** type in your MCP client
 - **Port**: 3001 (separate from the main API server on port 3000)
 
 **Benefits:**


### PR DESCRIPTION
## Changes Made

- Added **Streamable HTTP** connection type information for MCP server
- **MCP Server URL**: 
- **Connection Type**: Use **Streamable HTTP** type in your MCP client
- **Port**: 3001 (separate from the main API server on port 3000)

## Summary
This change adds the important connection type information that MCP clients need to properly connect to the server. Users should use **Streamable HTTP** type when connecting to the MCP server at .

## Technical Details
- MCP Server: HTTP endpoint at localhost:3001
- Connection Type: **Streamable HTTP** (important for proper MCP communication)
- Main API Server: HTTP endpoint at localhost:3000
- Clear separation of services and connection requirements

This will trigger a new patch release automatically.