### PR TITLE
docs: add MCP Connection URL and Streamable HTTP type to What You Get section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ npm start
 **✅ What You Get:**
 - **REST API**: `GET /hello` → `{"message": "Hello World!"}` at `http://localhost:3000`
 - **MCP Tool**: `get_hello` available to AI models at `ws://localhost:3001`
+- **MCP Connection URL**: `http://localhost:3001`
+- **Connection Type**: Use **Streamable HTTP** type in your MCP client
 - **OpenAPI Docs**: Complete documentation at `http://localhost:3000/openapi.json`
 - **Swagger UI**: Interactive docs at `http://localhost:3000/docs` ✨
 


### PR DESCRIPTION
## Changes Made

- Added **MCP Connection URL**:  to the What You Get section
- Added **Connection Type**: Use **Streamable HTTP** type in your MCP client
- Both pieces of information now appear prominently in the main benefits section

## Summary
This change adds the essential MCP connection information directly to the 'What You Get' section, making it immediately visible to users. They can now see both the connection URL and the required connection type at a glance.

## Technical Details
- **MCP Connection URL**: 
- **Connection Type**: **Streamable HTTP** type
- **Placement**: Added to the main 'What You Get' section for maximum visibility
- **Clarity**: Users know exactly how to connect to the MCP server

This will trigger a new patch release automatically.