### PR TITLE
docs: replace confusing id parameter with clear subfolder examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ api/
 ├── users/
 │   ├── get.js          → GET /users
 │   ├── post.js         → POST /users
-│   └── id/
-│       ├── get.js      → GET /users/:id
-│       ├── put.js      → PUT /users/:id
-│       └── delete.js   → DELETE /users/:id
+│   └── profile/
+│       ├── get.js      → GET /users/profile
+│       ├── put.js      → PUT /users/profile
+│       └── delete.js   → DELETE /users/profile
 ├── products/
 │   ├── get.js          → GET /products
 │   └── search/
@@ -114,26 +114,26 @@ api/
 - **`head.js`** → **HEAD** request
 - **`options.js`** → **OPTIONS** request
 
-### **🔗 Dynamic Routes with Parameters**
-Use folder names to create dynamic routes with parameters:
+### **🔗 Nested Routes with Subfolders**
+Use subfolders to create nested API routes:
 
 ```
 api/
 ├── users/
 │   ├── get.js          → GET /users
-│   └── id/
-│       ├── get.js      → GET /users/:id
-│       ├── put.js      → PUT /users/:id
-│       └── delete.js   → DELETE /users/:id
+│   └── profile/
+│       ├── get.js      → GET /users/profile
+│       ├── put.js      → PUT /users/profile
+│       └── delete.js   → DELETE /users/profile
 ```
 
-**Example**: `api/users/id/get.js` creates `GET /users/:id` where `:id` is a URL parameter accessible via `req.params.id`.
+**Example**: `api/users/profile/get.js` creates `GET /users/profile` endpoint.
 
 ### **🎯 MCP Tool Names**
 Your API endpoints automatically become MCP tools with names based on the HTTP method and path:
 - `api/hello/get.js` → MCP tool: `get_hello`
 - `api/users/post.js` → MCP tool: `post_users`
-- `api/users/id/put.js` → MCP tool: `put_users_by_id`
+- `api/users/profile/put.js` → MCP tool: `put_users_profile`
 
 
 


### PR DESCRIPTION
## Changes Made

- Replaced confusing uid=501(boqiangliang) gid=20(staff) groups=20(staff),12(everyone),61(localaccounts),79(_appserverusr),80(admin),81(_appserveradm),98(_lpadmin),33(_appstore),100(_lpoperator),204(_developer),250(_analyticsusers),395(com.apple.access_ftp),398(com.apple.access_screensharing),399(com.apple.access_ssh),400(com.apple.access_remote_ae),701(com.apple.sharepoint.group.1) parameter examples with clear subfolder examples
- Changed dynamic routes section to nested routes with subfolders
- Updated file structure examples to use  instead of uid=501(boqiangliang) gid=20(staff) groups=20(staff),12(everyone),61(localaccounts),79(_appserverusr),80(admin),81(_appserveradm),98(_lpadmin),33(_appstore),100(_lpoperator),204(_developer),250(_analyticsusers),395(com.apple.access_ftp),398(com.apple.access_screensharing),399(com.apple.access_ssh),400(com.apple.access_remote_ae),701(com.apple.sharepoint.group.1)
- Fixed MCP tool names to reflect the new structure

## Summary
Simplified the documentation by removing confusing parameter-based examples and using clear subfolder examples instead.

## Technical Changes

### Updated Examples
- **File Structure**: Changed from  to 
- **Route Examples**:  → 
- **MCP Tool Names**:  → 

### Section Renamed
- **Dynamic Routes with Parameters** → **Nested Routes with Subfolders**
- Removed confusing parameter syntax explanations
- Added clear subfolder-based routing examples

## Benefits
- **Clearer Understanding**: No more confusing parameter syntax
- **Realistic Examples**: Uses actual subfolder structure that developers will use
- **Simplified Learning**: Focus on practical folder organization
- **Better Clarity**: Examples now show how to organize related endpoints

## New Structure Example


This will trigger a new patch release automatically.