### PR TITLE
chore: bump version to 0.6.14 for patch release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-mcp-server",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "description": "A dynamic API framework with easy MCP (Model Context Protocol) integration for AI models",
   "main": "index.js",
   "exports": {

--- a/server.js
+++ b/server.js
@@ -399,4 +399,4 @@ module.exports = {
   hotReloader: null, // Will be set when server starts
   getLoadedRoutes: () => apiLoader.getRoutes()
 };
-// Version 0.0.1
+// Version 0.6.14


### PR DESCRIPTION
## Version Bump

This PR bumps the version from 0.6.13 to 0.6.14 for the patch release that includes the IPv6 binding fix.

## Changes

- Updated  version from 0.6.13 to 0.6.14
- Updated version comment in  from 0.0.1 to 0.6.14

## Context

This version bump follows the fix for issue #34 where the MCP server IPv6 binding issue was resolved for Kubernetes compatibility.

## Type

- [x] Patch release (bug fix)
- [ ] Minor release (new feature)
- [ ] Major release (breaking change)