### PR TITLE
fix: update OpenAPI generator test to expect version 0.6.14

### DIFF
--- a/__tests__/openapi-generator.test.js
+++ b/__tests__/openapi-generator.test.js
@@ -311,7 +311,7 @@ describe('OpenAPIGenerator', () => {
       const info = openapiGenerator.generateInfo();
       
       expect(info.title).toBe('Easy MCP Server API');
-      expect(info.version).toBe('0.6.13');
+      expect(info.version).toBe('0.6.14');
       expect(info.description).toContain('MCP');
     });
   });


### PR DESCRIPTION
## Summary

This PR fixes the failing OpenAPI generator test that was expecting version 0.6.13 but the package.json was updated to 0.6.14.

## Problem

The CI tests were failing because:
- Package.json version was updated to 0.6.14
- OpenAPI generator test was hardcoded to expect version 0.6.13
- This caused the release workflow to fail

## Solution

Updated the test expectation from '0.6.13' to '0.6.14' to match the current package version.

## Changes

- : Updated version expectation in test

## Testing

- ✅ Test now passes with version 0.6.14
- ✅ All other tests continue to pass

This fix will allow the release workflow to complete successfully and trigger the patch release.