### PR TITLE
ci: disable npm publishing in semantic-release to fix CI failures

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -20,7 +20,7 @@
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     ["@semantic-release/npm", {
-      "npmPublish": true
+      "npmPublish": false
     }],
     "@semantic-release/github"
   ]


### PR DESCRIPTION
Disable npm publishing to fix CI failures