### PR TITLE
ci: enable npm publishing in semantic-release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -20,7 +20,7 @@
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     ["@semantic-release/npm", {
-      "npmPublish": false
+      "npmPublish": true
     }],
     "@semantic-release/github"
   ]


### PR DESCRIPTION
## Summary

This PR enables npm package publishing in semantic-release.

## Changes

- Changed  to  in 

## Impact

- ✅ npm packages will now be automatically published to the npm registry
- ✅ GitHub releases will continue to work as before
- ✅ The NPM_TOKEN secret is already configured for authentication

## What This Enables

With this change, when semantic-release runs:
1. It will create a GitHub release (as before)
2. It will publish the npm package to the npm registry
3. The package will be available on npmjs.com

This completes the full CI/CD pipeline for both GitHub releases and npm publishing.