### PR TITLE
test: fix IPv6 binding test reliability and timeouts

### DIFF
--- a/__tests__/ipv6-binding.test.js
+++ b/__tests__/ipv6-binding.test.js
@@ -13,13 +13,20 @@ describe('IPv6 Binding Fix for Kubernetes Compatibility', () => {
 
   afterEach(async () => {
     if (mcpServer) {
-      mcpServer.stop();
+      try {
+        await mcpServer.stop();
+      } catch (error) {
+        // Ignore cleanup errors
+      }
     }
   });
 
   test('MCP server binds to all interfaces by default', async () => {
     // Start the MCP server
     await mcpServer.run();
+    
+    // Wait a moment for the server to fully start
+    await new Promise(resolve => setTimeout(resolve, 100));
     
     // Try to connect from localhost (IPv4)
     const localhostConnection = new Promise((resolve) => {
@@ -32,6 +39,11 @@ describe('IPv6 Binding Fix for Kubernetes Compatibility', () => {
         client.destroy();
         resolve(false);
       });
+      // Add timeout to prevent hanging
+      setTimeout(() => {
+        client.destroy();
+        resolve(false);
+      }, 2000);
     });
 
     // Try to connect from localhost (IPv6) - this might fail on some systems
@@ -45,9 +57,14 @@ describe('IPv6 Binding Fix for Kubernetes Compatibility', () => {
         client.destroy();
         resolve(false);
       });
+      // Add timeout to prevent hanging
+      setTimeout(() => {
+        client.destroy();
+        resolve(false);
+      }, 2000);
     });
 
-    // Wait for both connection attempts
+    // Wait for both connection attempts with timeout
     const [localhostSuccess, ipv6Success] = await Promise.all([
       localhostConnection,
       ipv6Connection
@@ -64,7 +81,7 @@ describe('IPv6 Binding Fix for Kubernetes Compatibility', () => {
     // The key fix is that we're no longer binding to 'localhost' which would
     // bind to IPv6 ::1 only, but instead binding to '0.0.0.0' which binds
     // to all IPv4 interfaces
-  });
+  }, 10000); // Increase timeout to 10 seconds
 
   test('MCP server constructor defaults to 0.0.0.0', () => {
     const defaultServer = new DynamicAPIMCPServer();
@@ -90,12 +107,21 @@ describe('IPv6 Binding Fix for Kubernetes Compatibility', () => {
     try {
       await mcpServer.run();
       
+      // Wait a moment for the server to fully start
+      await new Promise(resolve => setTimeout(resolve, 100));
+      
       // Check that the startup message shows the correct binding
       const startupLog = logs.find(log => log.includes('WebSocket server listening'));
       expect(startupLog).toBeDefined();
       expect(startupLog).toContain('0.0.0.0');
     } finally {
       console.log = originalLog;
+      // Ensure cleanup
+      try {
+        await mcpServer.stop();
+      } catch (error) {
+        // Ignore cleanup errors
+      }
     }
-  });
+  }, 10000); // Increase timeout to 10 seconds
 });


### PR DESCRIPTION
## Summary

This PR fixes reliability issues in the IPv6 binding test that was causing intermittent failures.

## Problem

The IPv6 binding test was failing with:
- Port conflicts ()
- Timeouts due to hanging connections
- Improper cleanup causing test instability

## Solution

- Added proper error handling in cleanup with try-catch blocks
- Added connection timeouts to prevent hanging
- Increased test timeout from 5s to 10s
- Added small delays for server startup
- Improved cleanup to ensure resources are properly released

## Changes

- : Enhanced test reliability and cleanup

## Testing

- ✅ All tests now pass consistently
- ✅ IPv6 binding test shows expected behavior:
  - IPv4 localhost: SUCCESS (confirms our fix works)
  - IPv6 localhost: FAILED (expected on some systems)
- ✅ No more port conflicts or timeouts

## Impact

This ensures the CI pipeline is stable and the IPv6 binding fix is properly validated.