### PR TITLE
fix: Update semantic-release configuration for self-hosted runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,25 @@ jobs:
       - name: Run linting
         run: npm run lint
 
+      - name: Setup npm authentication
+        run: |
+          # Create .npmrc with proper authentication
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+          echo "registry=https://registry.npmjs.org/" >> .npmrc
+          echo "always-auth=true" >> .npmrc
+          
+          # Verify npm authentication
+          /opt/homebrew/bin/npm whoami
+          
+          # Show npm configuration
+          /opt/homebrew/bin/npm config list
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_ENV: production
+          PATH: /opt/homebrew/bin:$PATH
         run: npx semantic-release

--- a/.releaserc
+++ b/.releaserc
@@ -20,7 +20,9 @@
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     ["@semantic-release/npm", {
-      "npmPublish": true
+      "npmPublish": true,
+      "registry": "https://registry.npmjs.org/",
+      "access": "public"
     }],
     "@semantic-release/github"
   ]


### PR DESCRIPTION
## Summary

This PR fixes the semantic-release configuration to work properly with the self-hosted runner environment.

## Changes

- **Fix NPM_TOKEN authentication**: Added proper npm authentication setup step in the workflow
- **Path configuration**: Ensured npm/npx commands are accessible by adding /opt/homebrew/bin to PATH
- **Workflow improvements**: Added npm authentication verification before running semantic-release
- **Configuration updates**: Updated .releaserc with explicit registry and access settings

## Problem

The previous workflow was failing because:
1. NPM_TOKEN was not being properly recognized in the self-hosted runner
2. npm/npx commands were not in the PATH
3. Missing npm authentication verification

## Solution

- Added dedicated 'Setup npm authentication' step that creates local .npmrc
- Uses full npm path (/opt/homebrew/bin/npm) for verification
- Added PATH environment variable to ensure commands are accessible
- Added npm authentication verification before semantic-release

## Testing

- [x] Local npm authentication test passed
- [x] semantic-release dry-run test passed (npm part)
- [x] Workflow syntax validation

This should resolve the semantic-release failures and enable automatic patch releases.