### PR TITLE
fix: Remove macOS-specific npm paths from workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,10 @@ jobs:
           echo "always-auth=true" >> .npmrc
           
           # Verify npm authentication
-          /opt/homebrew/bin/npm whoami
+          npm whoami
           
           # Show npm configuration
-          /opt/homebrew/bin/npm config list
+          npm config list
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -43,5 +43,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_ENV: production
-          PATH: /opt/homebrew/bin:$PATH
         run: npx semantic-release


### PR DESCRIPTION
## Summary

This PR fixes the npm path issue in the self-hosted runner workflow.

## Problem

The previous workflow was using macOS-specific npm paths (npm <command>

Usage:

npm install        install all the dependencies in your project
npm install <foo>  add the <foo> dependency to your project
npm test           run this project's tests
npm run <foo>      run the script named <foo>
npm <command> -h   quick help on <command>
npm -l             display usage info for all commands
npm help <term>    search for help on <term>
npm help npm       more involved overview

All commands:

    access, adduser, audit, bugs, cache, ci, completion,
    config, dedupe, deprecate, diff, dist-tag, docs, doctor,
    edit, exec, explain, explore, find-dupes, fund, get, help,
    help-search, init, install, install-ci-test, install-test,
    link, ll, login, logout, ls, org, outdated, owner, pack,
    ping, pkg, prefix, profile, prune, publish, query, rebuild,
    repo, restart, root, run, sbom, search, set, shrinkwrap,
    star, stars, start, stop, team, test, token, undeprecate,
    uninstall, unpublish, unstar, update, version, view, whoami

Specify configs in the ini-formatted file:
    /Users/boqiangliang/.npmrc
or on the command line via: npm <command> --key=value

More configuration info: npm help config
Configuration fields: npm help 7 config

npm@11.5.2 /opt/homebrew/lib/node_modules/npm) which don't exist on the Linux-based self-hosted runner, causing the workflow to fail with 'No such file or directory' errors.

## Solution

- Removed macOS-specific npm paths (npm <command>

Usage:

npm install        install all the dependencies in your project
npm install <foo>  add the <foo> dependency to your project
npm test           run this project's tests
npm run <foo>      run the script named <foo>
npm <command> -h   quick help on <command>
npm -l             display usage info for all commands
npm help <term>    search for help on <term>
npm help npm       more involved overview

All commands:

    access, adduser, audit, bugs, cache, ci, completion,
    config, dedupe, deprecate, diff, dist-tag, docs, doctor,
    edit, exec, explain, explore, find-dupes, fund, get, help,
    help-search, init, install, install-ci-test, install-test,
    link, ll, login, logout, ls, org, outdated, owner, pack,
    ping, pkg, prefix, profile, prune, publish, query, rebuild,
    repo, restart, root, run, sbom, search, set, shrinkwrap,
    star, stars, start, stop, team, test, token, undeprecate,
    uninstall, unpublish, unstar, update, version, view, whoami

Specify configs in the ini-formatted file:
    /Users/boqiangliang/.npmrc
or on the command line via: npm <command> --key=value

More configuration info: npm help config
Configuration fields: npm help 7 config

npm@11.5.2 /opt/homebrew/lib/node_modules/npm)
- Use standard  and  commands that are available in the runner's PATH
- Removed unnecessary PATH environment variable modification

## Testing

This should resolve the workflow failure and allow semantic-release to run properly on the self-hosted runner.