### PR TITLE
fix: Use explicit IPv4 binding (127.0.0.1) to resolve IPv6 binding issues

### DIFF
--- a/server.js
+++ b/server.js
@@ -298,7 +298,7 @@ function startServer() {
   if (process.env.MCP_ENABLED !== 'false') {
     try {
       mcpServer = new DynamicAPIMCPServer(
-        process.env.MCP_HOST || '0.0.0.0',
+        process.env.MCP_HOST || '127.0.0.1',
         process.env.MCP_PORT || 3001
       );
       
@@ -346,7 +346,7 @@ function startServer() {
     console.log('');
     if (mcpServer) {
       console.log('  🤖  MCP SERVER:');
-      console.log(`     • WebSocket:       ws://${process.env.MCP_HOST || '0.0.0.0'}:${process.env.MCP_PORT || 3001}`);
+      console.log(`     • WebSocket:       ws://${process.env.MCP_HOST || '127.0.0.1'}:${process.env.MCP_PORT || 3001}`);
       console.log(`     • Routes Loaded:   ${loadedRoutes.length} API endpoints`);
       console.log('');
     }

--- a/src/mcp/mcp-server.js
+++ b/src/mcp/mcp-server.js
@@ -7,7 +7,7 @@ const WebSocket = require('ws');
 const http = require('http');
 
 class DynamicAPIMCPServer {
-  constructor(host = '0.0.0.0', port = 3001) {
+  constructor(host = '127.0.0.1', port = 3001) {
     this.host = host;
     this.port = port;
     this.wss = null;


### PR DESCRIPTION
This PR changes the MCP server to use explicit IPv4 binding (127.0.0.1) instead of 0.0.0.0 to force IPv4-only binding and resolve the IPv6 binding issue.