### PR TITLE
chore: bump version to 0.6.16 for patch release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "easy-mcp-server",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "easy-mcp-server",
-      "version": "0.6.15",
+      "version": "0.6.16",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-mcp-server",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "description": "A dynamic API framework with easy MCP (Model Context Protocol) integration for AI models",
   "main": "index.js",
   "exports": {


### PR DESCRIPTION
This PR bumps the version to 0.6.16 for the patch release that includes the MCP server IPv4 binding fix.

## Changes
- Bump version from 0.6.15 to 0.6.16
- This is a patch release containing the MCP server IPv4 binding fix

## Release Notes
Version 0.6.16 includes:
- Fixed MCP server IPv4 binding for Kubernetes compatibility
- MCP server now binds to all IPv4 interfaces (0.0.0.0) instead of localhost only
- Enhanced MCP server constructor and host binding configuration
- Improved debug logging for host configuration tracking

This is a non-breaking patch release with no migration required.