### PR TITLE
fix: update test expectation for version 0.6.16

### DIFF
--- a/__tests__/openapi-generator.test.js
+++ b/__tests__/openapi-generator.test.js
@@ -311,7 +311,7 @@ describe('OpenAPIGenerator', () => {
       const info = openapiGenerator.generateInfo();
       
       expect(info.title).toBe('Easy MCP Server API');
-      expect(info.version).toBe('0.6.15');
+      expect(info.version).toBe('0.6.16');
       expect(info.description).toContain('MCP');
     });
   });


### PR DESCRIPTION
This PR fixes a test failure caused by the version bump to 0.6.16.

## Issue
The OpenAPI generator test was expecting version '0.6.15' but the package.json was updated to '0.6.16' for the patch release.

## Fix
Updated the test expectation in  to expect the correct version.

## Testing
- All tests now pass
- No functionality changes
- Simple test maintenance fix