### PR TITLE
fix: update OpenAPI generator test to use dynamic version from package.json

### DIFF
--- a/__tests__/openapi-generator.test.js
+++ b/__tests__/openapi-generator.test.js
@@ -311,7 +311,7 @@ describe('OpenAPIGenerator', () => {
       const info = openapiGenerator.generateInfo();
       
       expect(info.title).toBe('Easy MCP Server API');
-      expect(info.version).toBe('0.6.16');
+      expect(info.version).toBe(require('../package.json').version);
       expect(info.description).toContain('MCP');
     });
   });


### PR DESCRIPTION
## 🐛 Bug Fix

The OpenAPI generator test was failing because it was hardcoded to expect version '0.6.16', but after the version bump to '0.6.17', the test started failing.

## ✅ What's Fixed

- Updated the test to dynamically read the version from package.json instead of hardcoding it
- This ensures the test will continue to pass when versions are updated in the future

## 🔧 Technical Changes

- Changed  to 
- The test now automatically adapts to version changes

## 🧪 Testing

- All tests now pass successfully
- The test is more maintainable and won't break on future version bumps

## 🚀 Impact

This fix ensures that the CI/CD pipeline continues to work properly and that all tests pass before releases.