### PR TITLE
enhance: add request body schema to tool description for complete MCP Inspector visibility

### DIFF
--- a/src/mcp/mcp-server.js
+++ b/src/mcp/mcp-server.js
@@ -319,8 +319,14 @@ class DynamicAPIMCPServer {
         inputSchema.required = ['body'];
       }
 
-      // Create enhanced description that includes response schema info
+      // Create enhanced description that includes both request and response schema info
       let enhancedDescription = processor?.mcpDescription || openApi?.description || processor?.description || `Execute ${route.method} request to ${route.path}`;
+        
+      // Add request body schema information to description if available
+      if (openApi?.requestBody?.content?.['application/json']?.schema) {
+        const requestSchema = openApi.requestBody.content['application/json'].schema;
+        enhancedDescription += `\n\n**Request Body Schema:**\n\`\`\`json\n${JSON.stringify(requestSchema, null, 2)}\n\`\`\``;
+      }
         
       // Add response schema information to description if available
       if (openApi?.responses?.['200']?.content?.['application/json']?.schema) {
@@ -621,8 +627,14 @@ class DynamicAPIMCPServer {
             inputSchema.required = ['body'];
           }
           
-          // Create enhanced description that includes response schema info
+          // Create enhanced description that includes both request and response schema info
           let enhancedDescription = processor?.mcpDescription || openApi?.description || processor?.description || `Execute ${route.method} request to ${route.path}`;
+          
+          // Add request body schema information to description if available
+          if (openApi?.requestBody?.content?.['application/json']?.schema) {
+            const requestSchema = openApi.requestBody.content['application/json'].schema;
+            enhancedDescription += `\n\n**Request Body Schema:**\n\`\`\`json\n${JSON.stringify(requestSchema, null, 2)}\n\`\`\``;
+          }
           
           // Add response schema information to description if available
           if (openApi?.responses?.['200']?.content?.['application/json']?.schema) {


### PR DESCRIPTION
Add request body schema information to tool descriptions alongside response schema, ensuring complete API contract visibility in MCP Inspector. Now both request and response schemas are clearly displayed in tool descriptions.