### PR TITLE
Improve MCP tool descriptions by removing verbose JSON schema embedding

### DIFF
--- a/src/mcp/mcp-server.js
+++ b/src/mcp/mcp-server.js
@@ -319,19 +319,19 @@ class DynamicAPIMCPServer {
         inputSchema.required = ['body'];
       }
 
-      // Create enhanced description that includes both request and response schema info
+      // Create concise description without embedding full schemas
       let enhancedDescription = processor?.mcpDescription || openApi?.description || processor?.description || `Execute ${route.method} request to ${route.path}`;
-        
-      // Add request body schema information to description if available
+      
+      // Add brief schema information to description if available (without full JSON)
       if (openApi?.requestBody?.content?.['application/json']?.schema) {
         const requestSchema = openApi.requestBody.content['application/json'].schema;
-        enhancedDescription += `\n\n**Request Body Schema:**\n\`\`\`json\n${JSON.stringify(requestSchema, null, 2)}\n\`\`\``;
+        const requiredFields = requestSchema.required ? ` (required: ${requestSchema.required.join(', ')})` : '';
+        enhancedDescription += `\n\n**Request Body**: ${requestSchema.type || 'object'}${requiredFields}`;
       }
         
-      // Add response schema information to description if available
       if (openApi?.responses?.['200']?.content?.['application/json']?.schema) {
         const responseSchema = openApi.responses['200'].content['application/json'].schema;
-        enhancedDescription += `\n\n**Response Schema:**\n\`\`\`json\n${JSON.stringify(responseSchema, null, 2)}\n\`\`\``;
+        enhancedDescription += `\n\n**Response**: ${responseSchema.type || 'object'}`;
       }
 
       return {
@@ -627,19 +627,19 @@ class DynamicAPIMCPServer {
             inputSchema.required = ['body'];
           }
           
-          // Create enhanced description that includes both request and response schema info
+          // Create concise description without embedding full schemas
           let enhancedDescription = processor?.mcpDescription || openApi?.description || processor?.description || `Execute ${route.method} request to ${route.path}`;
           
-          // Add request body schema information to description if available
+          // Add brief schema information to description if available (without full JSON)
           if (openApi?.requestBody?.content?.['application/json']?.schema) {
             const requestSchema = openApi.requestBody.content['application/json'].schema;
-            enhancedDescription += `\n\n**Request Body Schema:**\n\`\`\`json\n${JSON.stringify(requestSchema, null, 2)}\n\`\`\``;
+            const requiredFields = requestSchema.required ? ` (required: ${requestSchema.required.join(', ')})` : '';
+            enhancedDescription += `\n\n**Request Body**: ${requestSchema.type || 'object'}${requiredFields}`;
           }
           
-          // Add response schema information to description if available
           if (openApi?.responses?.['200']?.content?.['application/json']?.schema) {
             const responseSchema = openApi.responses['200'].content['application/json'].schema;
-            enhancedDescription += `\n\n**Response Schema:**\n\`\`\`json\n${JSON.stringify(responseSchema, null, 2)}\n\`\`\``;
+            enhancedDescription += `\n\n**Response**: ${responseSchema.type || 'object'}`;
           }
 
           return {


### PR DESCRIPTION
## Summary

This PR improves the readability of MCP tool descriptions by replacing verbose JSON schema embedding with concise schema summaries.

## Changes Made

- **Before**: Full JSON schemas were embedded directly in the description field, making it extremely verbose and hard to read
- **After**: Brief schema information is shown (type and required fields) while keeping full schemas available in separate fields

## Example

**Before (verbose):**
json
{
  "type": "object",
  "properties": {
    "success": {
      "type": "boolean",
      "description": "Indicates whether the subtitle extraction was successful...",
      ...
    },
    ...
  }
}


**After (concise):**


## Benefits

1. **Improved Readability**: Descriptions are now concise and focused
2. **Better UX**: Users can quickly understand what the API does without scrolling through verbose JSON
3. **Maintained Functionality**: Full schemas are still available in  and  fields
4. **Consistent Format**: All MCP tools now have a uniform, clean description format

## Testing

- All existing tests pass
- Verified that MCP tool descriptions are now concise and readable
- Confirmed that full schema information is still available in separate fields

## Files Changed

-  - Updated description building logic in both  and  methods