### PR TITLE
chore: bump version to v0.6.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "easy-mcp-server",
-  "version": "0.6.16",
+  "version": "0.6.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "easy-mcp-server",
-      "version": "0.6.16",
+      "version": "0.6.18",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-mcp-server",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "description": "A dynamic API framework with easy MCP (Model Context Protocol) integration for AI models",
   "main": "index.js",
   "exports": {


### PR DESCRIPTION
## Summary

Bump version to v0.6.18 for patch release.

## Changes

- Bump package.json version from 0.6.17 to 0.6.18
- Update package-lock.json accordingly

## Release Notes

This patch release includes:
- Updated README with comprehensive annotation documentation
- Better documentation for all supported JSDoc annotations
- Cleaner, more scannable format

## Testing

- [x] Version bump applied correctly
- [x] Package files updated