### PR TITLE
chore: bump version to v1.0.38 for documentation release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "easy-mcp-server",
-  "version": "0.6.18",
+  "version": "1.0.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "easy-mcp-server",
-      "version": "0.6.18",
+      "version": "1.0.38",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-mcp-server",
-  "version": "0.6.18",
+  "version": "1.0.38",
   "description": "A dynamic API framework with easy MCP (Model Context Protocol) integration for AI models",
   "main": "index.js",
   "exports": {


### PR DESCRIPTION
## Summary

Bump version to v1.0.38 to align with the latest tag series and trigger a proper release.

## Changes

- Bump package.json version from 0.6.18 to 1.0.38
- Align version with the latest git tag v1.0.37
- Enable semantic-release to properly analyze commits for documentation changes

## Why This Change

The previous version 0.6.18 was out of sync with the latest git tag v1.0.37, causing semantic-release to not properly analyze commits for the README documentation updates.

## Testing

- [x] Version bump applied correctly
- [x] Package files updated
- [x] Ready for semantic-release analysis