### PR TITLE
fix: move comment-parser to dependencies and update init package version

### DIFF
--- a/bin/easy-mcp-server.js
+++ b/bin/easy-mcp-server.js
@@ -76,7 +76,7 @@ function initProject() {
       'test': 'jest'
     },
     'dependencies': {
-      'easy-mcp-server': '^1.0.38',
+      'easy-mcp-server': '^1.0.40',
       'express': '^4.18.2',
       'cors': '^2.8.5',
       'dotenv': '^16.3.1'

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "chokidar": "^3.5.3",
+    "comment-parser": "^1.4.1",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
@@ -33,7 +34,6 @@
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/github": "^9.2.6",
     "@semantic-release/npm": "^11.0.2",
-    "comment-parser": "^1.4.1",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
     "nodemon": "^3.1.10",


### PR DESCRIPTION
## Summary

This PR fixes a critical runtime dependency issue that prevents the server from starting.

## Problem

When using  and then trying to start the server, users get:


## Root Cause

The  package was incorrectly placed in  but it's required at runtime by the annotation parser.

## Changes

- **Move ** from  to  in main package.json
- **Update init command** to use current package version  instead of 

## Testing

- ✅  creates project successfully
- ✅ Generated project can start server without dependency errors
- ✅ All existing functionality preserved

## Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency fix

This fix ensures that users can successfully use the  command and start their servers immediately after project creation.