### PR TITLE
fix: update server test path to use src/server.js

### DIFF
--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -1,7 +1,7 @@
 const request = require('supertest');
 
 // Mock the server without actually starting it
-jest.mock('../server', () => {
+jest.mock('../src/server', () => {
   const express = require('express');
   const app = express();
   
@@ -46,7 +46,7 @@ describe('Server Basic Functionality', () => {
   let app;
   
   beforeAll(() => {
-    app = require('../server');
+    app = require('../src/server');
   });
   
   test('health endpoint should return OK status', async () => {


### PR DESCRIPTION
Fix server test path after moving server.js to src/ directory. Updates jest.mock and require paths to ensure all tests pass.