### PR TITLE
fix: use absolute paths for imports in server.js to ensure npm package compatibility

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -3,10 +3,11 @@ const express = require('express');
 const cors = require('cors');
 
 // Import core modules
-const APILoader = require('./core/api-loader');
-const OpenAPIGenerator = require('./core/openapi-generator');
-const DynamicAPIMCPServer = require('../mcp/mcp-server');
-const HotReloader = require('../utils/hot-reloader');
+const path = require('path');
+const APILoader = require(path.join(__dirname, 'core', 'api-loader'));
+const OpenAPIGenerator = require(path.join(__dirname, 'core', 'openapi-generator'));
+const DynamicAPIMCPServer = require(path.join(__dirname, '..', 'mcp', 'mcp-server'));
+const HotReloader = require(path.join(__dirname, '..', 'utils', 'hot-reloader'));
 
 // Create Express app
 const app = express();


### PR DESCRIPTION
Fix import path resolution issues in server.js when the package is installed from npm:

- Replace relative imports with path.join(__dirname, ...) for reliable module resolution
- Fixes 'Cannot find module' errors when package is installed from npm
- Ensures imports work correctly regardless of where server.js is executed from
- Resolves the issue where users get module not found errors after npm install