### PR TITLE
fix: correct import paths for mcp and utils modules in server.js

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -6,8 +6,8 @@ const cors = require('cors');
 const path = require('path');
 const APILoader = require(path.join(__dirname, 'core', 'api-loader'));
 const OpenAPIGenerator = require(path.join(__dirname, 'core', 'openapi-generator'));
-const DynamicAPIMCPServer = require(path.join(__dirname, '..', 'mcp', 'mcp-server'));
-const HotReloader = require(path.join(__dirname, '..', 'utils', 'hot-reloader'));
+const DynamicAPIMCPServer = require(path.join(__dirname, 'mcp', 'mcp-server'));
+const HotReloader = require(path.join(__dirname, 'utils', 'hot-reloader'));
 
 // Create Express app
 const app = express();


### PR DESCRIPTION
Fix the import paths for mcp and utils modules that were incorrectly pointing one level up:

- Fix path.join(__dirname, '..', 'mcp', 'mcp-server') to path.join(__dirname, 'mcp', 'mcp-server')
- Fix path.join(__dirname, '..', 'utils', 'hot-reloader') to path.join(__dirname, 'utils', 'hot-reloader')
- The mcp and utils directories are at the same level as core, not one level up
- This resolves the 'Cannot find module' error for mcp-server and hot-reloader

The directory structure is:
src/
├── core/
├── mcp/
└── utils/

So from src/server.js, we need to go to 'mcp/mcp-server' not '../mcp/mcp-server'