### PR TITLE
fix: correct MCP connection information in CLI output

### DIFF
--- a/bin/easy-mcp-server.js
+++ b/bin/easy-mcp-server.js
@@ -424,9 +424,11 @@ describe('Easy MCP Server', () => {
    - API Info: http://localhost:3000/api-info
 
 🔌 MCP (Model Context Protocol) Integration:
-   - MCP Server: ws://localhost:3000/mcp
+   - MCP Server: http://localhost:3001
    - MCP Tools: http://localhost:3000/mcp/tools
    - MCP Schema: http://localhost:3000/mcp/schema
+   - Transport Types: Streamable HTTP, Server-Sent Events (SSE)
+   - MCP Endpoints: GET /sse, POST /mcp, POST / (StreamableHttp)
 
 ⚙️ Server Type: Full-featured Easy MCP Server with:
    - Dynamic API discovery and loading


### PR DESCRIPTION
Fix the MCP connection information displayed in the CLI output:

- Change MCP Server from ws://localhost:3000/mcp to http://localhost:3001
- Add transport types: Streamable HTTP, Server-Sent Events (SSE)
- Add MCP endpoints: GET /sse, POST /mcp, POST / (StreamableHttp)
- Port 3001 is correct for MCP server, not 3000

The MCP server runs on port 3001 and supports multiple transport types including Streamable HTTP and SSE, not WebSocket on port 3000.