### PR TITLE
feat: Change MCP tool naming convention to put HTTP method at end

### DIFF
--- a/LLM.txt
+++ b/LLM.txt
@@ -167,7 +167,7 @@ module.exports = CreateUser;
 
 ### Tool Generation
 - Automatic tool discovery from API endpoints
-- Tool names: `{method}_{path}` (e.g., `post_users`)
+- Tool names: `{path}_{method}` (e.g., `users_post`)
 - Description from annotations or auto-generated
 - Input schema from request body annotations
 

--- a/__tests__/mcp.test.js
+++ b/__tests__/mcp.test.js
@@ -72,7 +72,7 @@ describe('MCP (Model Context Protocol) Support', () => {
       id: 1,
       method: 'tools/call',
       params: {
-        name: 'get_test',
+        name: 'test_get',
         arguments: {}
       }
     };

--- a/src/mcp/mcp-server.js
+++ b/src/mcp/mcp-server.js
@@ -497,8 +497,10 @@ class DynamicAPIMCPServer {
     try {
       const { name, arguments: args } = data;
       
-      // Parse the tool name to get method and path
-      const [method, ...pathParts] = name.split('_');
+      // Parse the tool name to get method and path (method is now at the end)
+      const parts = name.split('_');
+      const method = parts[parts.length - 1]; // Last part is the method
+      const pathParts = parts.slice(0, -1); // Everything except the last part is the path
       const path = '/' + pathParts.join('/');
       
       console.log('🔍 MCP Server: Tool call request:', { name, method, path });
@@ -508,7 +510,7 @@ class DynamicAPIMCPServer {
       console.log('🔍 MCP Server: Available routes:', routes.map(r => ({ method: r.method, path: r.path })));
       
       const route = routes.find(r => 
-        r.method.toLowerCase() === method.toUpperCase() && 
+        r.method.toUpperCase() === method.toUpperCase() && 
         r.path === path
       );
       
@@ -643,7 +645,7 @@ class DynamicAPIMCPServer {
           }
 
           return {
-            name: `${route.method.toLowerCase()}_${route.path.replace(/\//g, '_').replace(/^_/, '')}`,
+            name: `${route.path.replace(/\//g, '_').replace(/^_/, '')}_${route.method.toLowerCase()}`,
             description: enhancedDescription,
             inputSchema: inputSchema,
             // Add response schema information as separate field for compatibility

--- a/src/server.js
+++ b/src/server.js
@@ -162,7 +162,7 @@ app.get('/mcp/tools', (req, res) => {
   try {
     const routes = apiLoader.getRoutes();
     const tools = routes.map(route => ({
-      name: `${route.method.toLowerCase()}_${route.path.replace(/\//g, '_').replace(/^_/, '')}`,
+      name: `${route.path.replace(/\//g, '_').replace(/^_/, '')}_${route.method.toLowerCase()}`,
       description: route.processorInstance?.description || `Execute ${route.method} request to ${route.path}`,
       method: route.method,
       path: route.path,
@@ -189,14 +189,17 @@ app.post('/mcp/execute/:toolName', (req, res) => {
   const { body, query, headers } = req.body;
   
   try {
-    // Parse the tool name to get method and path
-    const [method, ...pathParts] = toolName.split('_');
+    // Parse the tool name to get method and path (method is now at the end)
+    const parts = toolName.split('_');
+    const method = parts[parts.length - 1]; // Last part is the method
+    const pathParts = parts.slice(0, -1); // Everything except the last part is the path
     const path = '/' + pathParts.join('/');
     
     // Find the route
     const routes = apiLoader.getRoutes();
+    
     const route = routes.find(r => 
-      r.method.toLowerCase() === method.toUpperCase() && 
+      r.method.toUpperCase() === method.toUpperCase() && 
       r.path === path
     );
     


### PR DESCRIPTION
This PR changes the MCP tool naming convention from putting the HTTP method at the beginning to putting it at the end.