### PR TITLE
fix: update BaseAPI imports to use package import instead of relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ easy-mcp-server
 Your project includes a working example at `api/example/get.js`:
 
 ```javascript
-const BaseAPI = require('../../src/core/base-api');
+const BaseAPI = require('easy-mcp-server/base-api');
 
 /**
  * @description Get a greeting message
@@ -186,7 +186,7 @@ Shows comprehensive usage information and examples.
 
 2. **Here's the code:**
    ```javascript
-   const BaseAPI = require('../../src/core/base-api');
+   const BaseAPI = require('easy-mcp-server/base-api');
 
    /**
     * @description Create a new book

--- a/api/example/delete.js
+++ b/api/example/delete.js
@@ -1,4 +1,4 @@
-const BaseAPI = require('../../src/core/base-api');
+const BaseAPI = require('easy-mcp-server/base-api');
 
 /**
  * @description Delete an item

--- a/api/example/get.js
+++ b/api/example/get.js
@@ -1,4 +1,4 @@
-const BaseAPI = require('../../src/core/base-api');
+const BaseAPI = require('easy-mcp-server/base-api');
 
 /**
  * @description Get a greeting message

--- a/api/example/patch.js
+++ b/api/example/patch.js
@@ -1,4 +1,4 @@
-const BaseAPI = require('../../src/core/base-api');
+const BaseAPI = require('easy-mcp-server/base-api');
 
 /**
  * @description Partially update an item

--- a/api/example/post.js
+++ b/api/example/post.js
@@ -1,4 +1,4 @@
-const BaseAPI = require('../../src/core/base-api');
+const BaseAPI = require('easy-mcp-server/base-api');
 
 /**
  * @description Create a new user with validation

--- a/api/example/put.js
+++ b/api/example/put.js
@@ -1,4 +1,4 @@
-const BaseAPI = require('../../src/core/base-api');
+const BaseAPI = require('easy-mcp-server/base-api');
 
 /**
  * @description Update an item


### PR DESCRIPTION
## Summary
This PR fixes BaseAPI imports in all example files and documentation to use the proper package import syntax instead of relative paths.

## Changes Made
- Updated all example files (get.js, post.js, put.js, patch.js, delete.js) to use `easy-mcp-server/base-api` import
- Updated README examples to show correct import syntax
- Improved maintainability and follows Node.js best practices
- Ensures proper package imports for published packages

## Benefits
- ✅ **Proper package imports** - Uses the official package export
- ✅ **Better maintainability** - No more relative path dependencies  
- ✅ **Cleaner code** - Follows Node.js best practices
- ✅ **Works in published packages** - Users can import BaseAPI correctly
- ✅ **Tested and verified** - All imports work correctly

## Files Changed
- `api/example/get.js`
- `api/example/post.js`
- `api/example/put.js`
- `api/example/patch.js`
- `api/example/delete.js`
- `README.md`

## Testing
- [x] All example files import BaseAPI correctly
- [x] README examples show proper import syntax
- [x] Package import works as expected