### PR TITLE
docs: add MCP inspector information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ module.exports = GetExample;
 - **MCP Tools**: Available to AI models
   - **URL**: `http://localhost:3001`
   - **Type**: Streamable HTTP
+  - **Inspector**: Use `npx @modelcontextprotocol/inspector` to inspect MCP tools and features
 - **OpenAPI**: `http://localhost:3000/openapi.json`
 - **Swagger UI**: `http://localhost:3000/docs`
 - **LLM.txt**: `http://localhost:3000/LLM.txt` (AI context)


### PR DESCRIPTION
## Summary
This PR adds information about the MCP inspector tool to help users inspect and test their MCP tools and features.

## Changes Made
- Added `npx @modelcontextprotocol/inspector` command to MCP Tools section
- Help users inspect and test their MCP tools and features
- Enhance developer experience with debugging capabilities
- Provide practical tooling information for MCP integration

## Benefits
- ✅ **Better debugging** - Users can visually inspect MCP tools
- ✅ **Enhanced testing** - Easy way to test MCP tool functionality
- ✅ **Improved DX** - Better developer experience for MCP integration
- ✅ **Practical tooling** - Real-world tooling information

## Files Changed
- `README.md`

## Testing
- [x] README formatting looks correct
- [x] MCP inspector command is properly documented
- [x] Information is placed in appropriate section