### PR TITLE
Use live example server as connection reference

### DIFF
--- a/src/mcp/mcp-info.html
+++ b/src/mcp/mcp-info.html
@@ -289,7 +289,7 @@
             <h4>🔧 Development Tools</h4>
             <p><strong>MCP Inspector:</strong></p>
             <div class="code">npx @modelcontextprotocol/inspector</div>
-            <p>Then use URL: <span class="code">http://localhost:3001</span></p>
+            <p>Then use URL: <span class="code">https://mcp.easynet.world</span></p>
             <p><em>Uses streamable HTTP transport for real-time MCP communication</em></p>
         </div>
         
@@ -313,7 +313,7 @@
             <h4>💻 AI Applications</h4>
             <p><strong>Claude Desktop:</strong></p>
             <p>Add this server to your Claude Desktop configuration:</p>
-            <div class="code">http://localhost:3001</div>
+            <div class="code">https://mcp.easynet.world</div>
             <p><em>Supports streamable HTTP for efficient MCP communication</em></p>
         </div>
         


### PR DESCRIPTION
## 🌐 Live Example Server Integration

This PR updates the MCP info page to use the live example server  as the connection reference instead of .

### ✨ Changes Made

**🔧 Development Tools Section:**
- Updated MCP Inspector URL from  to 

**💻 AI Applications Section:**
- Updated Claude Desktop configuration from  to 

### 🎯 Benefits

**🚀 Immediate Testing:**
- Users can test connections immediately without running local server
- Real-world example demonstrates actual capabilities
- No setup required to see examples in action

**📚 Better User Experience:**
- More practical and actionable connection instructions
- Demonstrates live server functionality
- Provides working examples users can try right away

**🔗 Consistent Branding:**
- All examples now reference the live easynet.world server
- Reinforces the live demo availability
- Better brand consistency across all references

### 📋 Updated Sections

1. **Development Tools** - MCP Inspector now uses live server
2. **AI Applications** - Claude Desktop config uses live server
3. **Live Demo** - Already referenced the live server
4. **Cursor IDE** - Already configured with live server

This makes the connection instructions much more practical and immediately useful for users who want to test the MCP server capabilities.