### PR TITLE
fix: correct grammar - use 'a MCP' instead of 'an MCP'

### DIFF
--- a/src/mcp/mcp-info.html
+++ b/src/mcp/mcp-info.html
@@ -282,7 +282,7 @@
         </div>
         
         <div class="warning">
-            This is an MCP (Model Context Protocol) server, not a web application. Use MCP clients to connect and interact with the available tools.
+            This is a MCP (Model Context Protocol) server, not a web application. Use MCP clients to connect and interact with the available tools.
         </div>
         
         <div class="info-box">


### PR DESCRIPTION
## 🔧 Grammar Fix

This PR corrects a grammatical error in the MCP info page warning message.

### 📝 What's Fixed

**Grammar Correction:**
- Changed 'This is an MCP' to 'This is a MCP'
- MCP starts with vowel sound (em-see-pee) so should use 'a' not 'an'
- Improves grammatical accuracy and professional presentation

### ✨ Benefits

**📚 Better Grammar:**
- Corrects article usage for acronyms starting with vowel sounds
- More professional and accurate language
- Better user experience with proper grammar

### 🔧 Technical Details

- Updated warning message in 
- Simple one-word change for grammatical accuracy
- Maintains all existing functionality and styling

This is a minor but important improvement for professional presentation of the MCP server info page.