### PR TITLE
feat: Add customizable MCP info page support

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,37 @@ easy-mcp-server --help             # Show all options
 PORT=3000                          # API server port
 MCP_PORT=3001                      # MCP server port
 NODE_ENV=development               # Environment
+MCP_INFO_HTML_PATH=/path/to/custom.html  # Custom MCP info page
 ```
+
+### Custom MCP Info Page
+
+You can customize the MCP info page that's served at `http://localhost:3001/` in three ways:
+
+#### 1. **Project Root File** (Recommended)
+Create a `mcp-info.html` file in your project root:
+```bash
+# Create your custom HTML file
+touch mcp-info.html
+```
+
+#### 2. **Environment Variable**
+Set the `MCP_INFO_HTML_PATH` environment variable:
+```bash
+export MCP_INFO_HTML_PATH="/path/to/your/custom.html"
+```
+
+#### 3. **Example Template**
+Use the provided example as a starting point:
+```bash
+cp mcp-info-example.html mcp-info.html
+# Edit mcp-info.html with your custom content
+```
+
+**Priority Order:**
+1. Environment variable `MCP_INFO_HTML_PATH`
+2. `mcp-info.html` in project root
+3. Default built-in page
 
 ---
 

--- a/__tests__/mcp-info-customization.test.js
+++ b/__tests__/mcp-info-customization.test.js
@@ -1,0 +1,256 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// Import the MCP server
+const DynamicAPIMCPServer = require('../src/mcp/mcp-server');
+
+describe('MCP Info Page Customization', () => {
+  let mcpServer;
+  let tempDir;
+  let customHtmlPath;
+  let serverPort;
+
+  beforeAll(async () => {
+    // Create a temporary directory for testing
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-info-test-'));
+    customHtmlPath = path.join(tempDir, 'custom-mcp-info.html');
+    
+    // Start MCP server on a random port
+    serverPort = 3001 + Math.floor(Math.random() * 1000);
+    mcpServer = new DynamicAPIMCPServer('127.0.0.1', serverPort);
+    await mcpServer.run();
+  });
+
+  afterAll(async () => {
+    if (mcpServer) {
+      mcpServer.stop();
+    }
+    // Clean up temporary directory
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  // Helper function to make HTTP requests to MCP server
+  const makeRequest = (path = '/') => {
+    return new Promise((resolve, reject) => {
+      const options = {
+        hostname: '127.0.0.1',
+        port: serverPort,
+        path: path,
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      };
+
+      const req = http.request(options, (res) => {
+        let data = '';
+        res.on('data', (chunk) => {
+          data += chunk;
+        });
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode,
+            headers: res.headers,
+            text: data
+          });
+        });
+      });
+
+      req.on('error', (err) => {
+        reject(err);
+      });
+
+      req.end();
+    });
+  };
+
+  test('should serve default MCP info page when no custom file exists', async () => {
+    const response = await makeRequest('/');
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toMatch(/text\/html/);
+    expect(response.text).toContain('Easy MCP Server');
+    expect(response.text).toContain('Model Context Protocol Server');
+  });
+
+  test('should serve custom HTML file from project root', async () => {
+    // Create a custom HTML file in project root
+    const customHtml = `
+<!DOCTYPE html>
+<html>
+<head>
+    <title>My Custom MCP Server</title>
+</head>
+<body>
+    <h1>🚀 My Custom MCP Server</h1>
+    <p>This is my custom MCP info page!</p>
+</body>
+</html>`;
+
+    const projectRootHtmlPath = path.join(process.cwd(), 'mcp-info.html');
+    
+    // Write custom HTML to project root
+    fs.writeFileSync(projectRootHtmlPath, customHtml);
+
+    try {
+      const response = await makeRequest('/');
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['content-type']).toMatch(/text\/html/);
+      expect(response.text).toContain('My Custom MCP Server');
+      expect(response.text).toContain('This is my custom MCP info page!');
+    } finally {
+      // Clean up the custom HTML file
+      if (fs.existsSync(projectRootHtmlPath)) {
+        fs.unlinkSync(projectRootHtmlPath);
+      }
+    }
+  });
+
+  test('should serve custom HTML file from environment variable path', async () => {
+    // Create a custom HTML file
+    const customHtml = `
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Environment Custom MCP Server</title>
+</head>
+<body>
+    <h1>🌍 Environment Custom MCP Server</h1>
+    <p>This is loaded from environment variable!</p>
+</body>
+</html>`;
+
+    fs.writeFileSync(customHtmlPath, customHtml);
+
+    // Set environment variable
+    const originalEnv = process.env.MCP_INFO_HTML_PATH;
+    process.env.MCP_INFO_HTML_PATH = customHtmlPath;
+
+    try {
+      const response = await makeRequest('/');
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['content-type']).toMatch(/text\/html/);
+      expect(response.text).toContain('Environment Custom MCP Server');
+      expect(response.text).toContain('This is loaded from environment variable!');
+    } finally {
+      // Restore original environment variable
+      if (originalEnv) {
+        process.env.MCP_INFO_HTML_PATH = originalEnv;
+      } else {
+        delete process.env.MCP_INFO_HTML_PATH;
+      }
+    }
+  });
+
+  test('should prioritize environment variable over project root file', async () => {
+    // Create two different custom HTML files
+    const projectRootHtml = `
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Project Root MCP Server</title>
+</head>
+<body>
+    <h1>📁 Project Root MCP Server</h1>
+    <p>This is from project root!</p>
+</body>
+</html>`;
+
+    const envHtml = `
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Environment MCP Server</title>
+</head>
+<body>
+    <h1>🌍 Environment MCP Server</h1>
+    <p>This is from environment variable!</p>
+</body>
+</html>`;
+
+    const projectRootHtmlPath = path.join(process.cwd(), 'mcp-info.html');
+    
+    // Write both files
+    fs.writeFileSync(projectRootHtmlPath, projectRootHtml);
+    fs.writeFileSync(customHtmlPath, envHtml);
+
+    // Set environment variable
+    const originalEnv = process.env.MCP_INFO_HTML_PATH;
+    process.env.MCP_INFO_HTML_PATH = customHtmlPath;
+
+    try {
+      const response = await makeRequest('/');
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['content-type']).toMatch(/text\/html/);
+      // Should serve the environment variable file, not the project root file
+      expect(response.text).toContain('Environment MCP Server');
+      expect(response.text).toContain('This is from environment variable!');
+      expect(response.text).not.toContain('Project Root MCP Server');
+    } finally {
+      // Clean up files and environment
+      if (fs.existsSync(projectRootHtmlPath)) {
+        fs.unlinkSync(projectRootHtmlPath);
+      }
+      if (originalEnv) {
+        process.env.MCP_INFO_HTML_PATH = originalEnv;
+      } else {
+        delete process.env.MCP_INFO_HTML_PATH;
+      }
+    }
+  });
+
+  test('should handle missing custom HTML file gracefully', async () => {
+    // Set environment variable to non-existent file
+    const originalEnv = process.env.MCP_INFO_HTML_PATH;
+    process.env.MCP_INFO_HTML_PATH = '/path/to/nonexistent/file.html';
+
+    try {
+      const response = await makeRequest('/');
+
+      // Should fall back to default page
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['content-type']).toMatch(/text\/html/);
+      expect(response.text).toContain('Easy MCP Server');
+    } finally {
+      // Restore original environment variable
+      if (originalEnv) {
+        process.env.MCP_INFO_HTML_PATH = originalEnv;
+      } else {
+        delete process.env.MCP_INFO_HTML_PATH;
+      }
+    }
+  });
+
+  test('should handle invalid HTML file gracefully', async () => {
+    // Create an invalid HTML file
+    const invalidHtml = 'This is not valid HTML content';
+    fs.writeFileSync(customHtmlPath, invalidHtml);
+
+    // Set environment variable
+    const originalEnv = process.env.MCP_INFO_HTML_PATH;
+    process.env.MCP_INFO_HTML_PATH = customHtmlPath;
+
+    try {
+      const response = await makeRequest('/');
+
+      // Should still serve the file (even if invalid HTML)
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['content-type']).toMatch(/text\/html/);
+      expect(response.text).toContain('This is not valid HTML content');
+    } finally {
+      // Restore original environment variable
+      if (originalEnv) {
+        process.env.MCP_INFO_HTML_PATH = originalEnv;
+      } else {
+        delete process.env.MCP_INFO_HTML_PATH;
+      }
+    }
+  });
+});

--- a/mcp-info-example.html
+++ b/mcp-info-example.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>My Custom MCP Server</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            background: #f5f5f5;
+        }
+        .container {
+            background: white;
+            padding: 30px;
+            border-radius: 10px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        h1 {
+            color: #333;
+            text-align: center;
+            margin-bottom: 20px;
+        }
+        .info-box {
+            background: #e8f4f8;
+            border: 1px solid #bee5eb;
+            border-radius: 5px;
+            padding: 15px;
+            margin: 15px 0;
+        }
+        .code {
+            background: #f8f9fa;
+            border: 1px solid #e9ecef;
+            border-radius: 3px;
+            padding: 2px 6px;
+            font-family: monospace;
+            font-size: 14px;
+        }
+        .links {
+            text-align: center;
+            margin-top: 30px;
+        }
+        .links a {
+            display: inline-block;
+            margin: 5px 10px;
+            padding: 8px 16px;
+            background: #007bff;
+            color: white;
+            text-decoration: none;
+            border-radius: 5px;
+        }
+        .links a:hover {
+            background: #0056b3;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>🚀 My Custom MCP Server</h1>
+        
+        <div class="info-box">
+            <h3>📡 Server Information</h3>
+            <p>This is my custom MCP (Model Context Protocol) server.</p>
+            <p>Connect using: <span class="code">http://localhost:3001</span></p>
+        </div>
+        
+        <div class="info-box">
+            <h3>🔧 Development Tools</h3>
+            <p>Use MCP Inspector to connect:</p>
+            <p><span class="code">npx @modelcontextprotocol/inspector</span></p>
+            <p>Then use URL: <span class="code">http://localhost:3001</span></p>
+        </div>
+        
+        <div class="info-box">
+            <h3>💻 Cursor IDE</h3>
+            <p>Add to your Cursor MCP configuration:</p>
+            <p><span class="code">~/.cursor/mcp.json</span></p>
+            <pre style="background: #f8f9fa; padding: 10px; border-radius: 5px; overflow-x: auto;">
+{
+  "mcpServers": {
+    "my-server": {
+      "url": "http://localhost:3001/",
+      "transport": "http"
+    }
+  }
+}</pre>
+        </div>
+        
+        <div class="links">
+            <a href="https://github.com/modelcontextprotocol/inspector" target="_blank">MCP Inspector</a>
+            <a href="https://modelcontextprotocol.io" target="_blank">MCP Documentation</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/mcp/mcp-server.js
+++ b/src/mcp/mcp-server.js
@@ -178,8 +178,29 @@ class DynamicAPIMCPServer {
     const path = require('path');
     
     try {
-      const htmlPath = path.join(__dirname, 'mcp-info.html');
-      const html = fs.readFileSync(htmlPath, 'utf8');
+      // Check for custom HTML file paths in order of priority:
+      // 1. Environment variable MCP_INFO_HTML_PATH
+      // 2. Custom file in project root (mcp-info.html)
+      // 3. Default file in src/mcp directory
+      const envHtmlPath = process.env.MCP_INFO_HTML_PATH;
+      const customHtmlPath = path.join(process.cwd(), 'mcp-info.html');
+      const defaultHtmlPath = path.join(__dirname, 'mcp-info.html');
+      
+      let htmlPath;
+      let html;
+      
+      if (envHtmlPath && fs.existsSync(envHtmlPath)) {
+        htmlPath = envHtmlPath;
+        console.log('🔧 Using custom MCP info page from environment:', htmlPath);
+      } else if (fs.existsSync(customHtmlPath)) {
+        htmlPath = customHtmlPath;
+        console.log('🔧 Using custom MCP info page from project root:', htmlPath);
+      } else {
+        htmlPath = defaultHtmlPath;
+        console.log('🔧 Using default MCP info page:', htmlPath);
+      }
+      
+      html = fs.readFileSync(htmlPath, 'utf8');
       
       res.writeHead(200, { 'Content-Type': 'text/html' });
       res.end(html);


### PR DESCRIPTION
## 🎨 Customizable MCP Info Page

This PR adds the ability for users to customize the MCP info page that's served at the root endpoint of the MCP server.

### ✨ Features

- **Three customization methods:**
  1. **Project Root File**: Create `mcp-info.html` in project root
  2. **Environment Variable**: Set `MCP_INFO_HTML_PATH` to any custom HTML file
  3. **Default Fallback**: Uses built-in page if no custom file found

- **Priority System**: Environment variable > Project root file > Default page

- **Example Template**: Includes `mcp-info-example.html` as a starting point

### 🧪 Testing

- Added comprehensive test coverage with 6 test cases
- Tests cover all customization methods and edge cases
- All existing tests continue to pass

### 📚 Documentation

- Updated README.md with customization instructions
- Added environment variable documentation
- Included usage examples and priority order

### 🔄 Backward Compatibility

- Existing installations continue to work unchanged
- No breaking changes to existing functionality

### 🚀 Usage Examples

```bash
# Method 1: Project root file
touch mcp-info.html
# Edit with your custom content

# Method 2: Environment variable
export MCP_INFO_HTML_PATH="/path/to/your/custom.html"

# Method 3: Use example template
cp mcp-info-example.html mcp-info.html
```

This enhancement gives users complete control over their MCP server's info page while maintaining the framework's simplicity and reliability.