### PR TITLE
fix: Change 'html' variable to const in MCP server

### DIFF
--- a/src/mcp/mcp-server.js
+++ b/src/mcp/mcp-server.js
@@ -187,7 +187,6 @@ class DynamicAPIMCPServer {
       const defaultHtmlPath = path.join(__dirname, 'mcp-info.html');
       
       let htmlPath;
-      let html;
       
       if (envHtmlPath && fs.existsSync(envHtmlPath)) {
         htmlPath = envHtmlPath;
@@ -200,7 +199,7 @@ class DynamicAPIMCPServer {
         console.log('🔧 Using default MCP info page:', htmlPath);
       }
       
-      html = fs.readFileSync(htmlPath, 'utf8');
+      const html = fs.readFileSync(htmlPath, 'utf8');
       
       res.writeHead(200, { 'Content-Type': 'text/html' });
       res.end(html);


### PR DESCRIPTION
## 🔧 Linting Fix

This PR fixes an ESLint error in the MCP server:

- **Issue**: Variable 'html' was declared with 'let' but never reassigned
- **Fix**: Changed to 'const' declaration
- **Error**: prefer-const ESLint rule violation

This is a simple fix that ensures the code follows ESLint best practices and allows the CI/CD pipeline to pass successfully.