### PR TITLE
chore: eslint fixes for CI

### DIFF
--- a/__tests__/mcp-enhanced-resources.test.js
+++ b/__tests__/mcp-enhanced-resources.test.js
@@ -206,16 +206,16 @@ You are a helpful assistant that specializes in {{domain}}.
 
     test('should load JSON files as prompts with metadata', async () => {
       const jsonContent = JSON.stringify({
-        name: "code_review_prompt",
-        description: "Prompt for code review assistance",
-        instructions: "Review the following {{language}} code for {{review_type}} issues:\n\n{{code}}",
+        name: 'code_review_prompt',
+        description: 'Prompt for code review assistance',
+        instructions: 'Review the following {{language}} code for {{review_type}} issues:\n\n{{code}}',
         arguments: {
           properties: {
-            language: { description: "Programming language" },
-            review_type: { description: "Type of review to perform" },
-            code: { description: "Code to review" }
+            language: { description: 'Programming language' },
+            review_type: { description: 'Type of review to perform' },
+            code: { description: 'Code to review' }
           },
-          required: ["language", "code"]
+          required: ['language', 'code']
         }
       }, null, 2);
       await fs.writeFile(path.join(promptsDir, 'code_review.json'), jsonContent);

--- a/src/mcp/mcp-server.js
+++ b/src/mcp/mcp-server.js
@@ -1484,8 +1484,7 @@ class DynamicAPIMCPServer {
       '.vtt': 'text/vtt',
       '.srt': 'text/x-subrip',
       '.sub': 'text/x-subviewer',
-      '.smi': 'text/x-sami',
-      '.srt': 'text/x-subrip'
+      '.smi': 'text/x-sami'
     };
     
     return mimeTypes[ext.toLowerCase()] || 'text/plain';


### PR DESCRIPTION
Apply eslint fixes:\n- Single quotes in tests\n- Remove duplicate '.srt' MIME map key\n\nNo functional changes; ensures CI lint step passes.