### PR TITLE
fix: improve CI test reliability with better retry logic

### DIFF
--- a/__tests__/mcp-hot-reload-crud.test.js
+++ b/__tests__/mcp-hot-reload-crud.test.js
@@ -90,12 +90,12 @@ Use this prompt to test hot reload functionality.`;
       await fs.writeFile(promptFile, promptContent);
 
       // Wait for file watcher to detect the change - increased timeout for CI
-      await new Promise(resolve => setTimeout(resolve, 500));
+      await new Promise(resolve => setTimeout(resolve, 1000));
 
       // Wait for prompt to be loaded with retry logic for CI
       let retries = 0;
-      while (mcpServer.prompts.size === 0 && retries < 10) {
-        await new Promise(resolve => setTimeout(resolve, 100));
+      while (mcpServer.prompts.size === 0 && retries < 20) {
+        await new Promise(resolve => setTimeout(resolve, 200));
         retries++;
       }
 
@@ -210,12 +210,12 @@ This is a test resource with some content.
       await fs.writeFile(resourceFile, resourceContent);
 
       // Wait for file watcher to detect the change - increased timeout for CI
-      await new Promise(resolve => setTimeout(resolve, 500));
+      await new Promise(resolve => setTimeout(resolve, 1000));
 
       // Wait for resource to be loaded with retry logic for CI
       let retries = 0;
-      while (mcpServer.resources.size === 0 && retries < 10) {
-        await new Promise(resolve => setTimeout(resolve, 100));
+      while (mcpServer.resources.size === 0 && retries < 20) {
+        await new Promise(resolve => setTimeout(resolve, 200));
         retries++;
       }
 


### PR DESCRIPTION
## 🔧 CI Test Reliability Improvement

This PR further improves the reliability of the hot reload CRUD tests in CI environments by implementing more robust retry logic.

### 🐛 Problem
The previous fix with 500ms timeout and 10 retries was still not sufficient for the slower CI environment. Tests were still failing due to timing issues with asynchronous file processing.

### ✅ Solution
- **Increased initial timeout**: Changed from 500ms to 1000ms for initial file watcher detection
- **Enhanced retry logic**: Increased retry attempts from 10 to 20 with 200ms intervals
- **Better timing**: More generous timeouts to handle slower CI environments
- **Maintained functionality**: All tests still pass locally with improved reliability

### 🧪 Testing
- All tests pass locally ✅
- Improved retry logic handles timing variations
- Better suited for CI environments with slower file processing

### 📁 Files Changed
- `__tests__/mcp-hot-reload-crud.test.js`: Enhanced retry logic with better timing

This fix ensures that the hot reload CRUD functionality works reliably across all environments, including slower CI environments.