### PR TITLE
fix: increase Jest timeout for hot reload tests

### DIFF
--- a/__tests__/mcp-hot-reload-crud.test.js
+++ b/__tests__/mcp-hot-reload-crud.test.js
@@ -11,6 +11,9 @@ const os = require('os');
 const DynamicAPIMCPServer = require('../src/mcp/mcp-server');
 
 describe('MCP Server Hot Reload CRUD Operations', () => {
+  // Increase timeout for CI environments
+  jest.setTimeout(15000);
+  
   let mcpServer;
   let tempDir;
   let promptsDir;


### PR DESCRIPTION
## 🔧 Jest Timeout Fix for CI

This PR fixes the test timeout issue in CI environments by increasing the Jest timeout for hot reload tests.

### 🐛 Problem
The hot reload CRUD tests were timing out in CI with Jest's default 5000ms timeout. The tests were working correctly but needed more time in slower CI environments.

### ✅ Solution
- **Increased Jest timeout**: Added `jest.setTimeout(15000)` to give tests 15 seconds instead of 5 seconds
- **CI-friendly timing**: Ensures tests have enough time to complete file watcher operations
- **Maintained functionality**: All tests still pass locally and should now pass in CI

### 🧪 Testing
- All 12 hot reload tests pass locally ✅
- Timeout increased specifically for the hot reload test suite
- No changes to test logic, only timeout configuration

### 📁 Files Changed
- `__tests__/mcp-hot-reload-crud.test.js`: Added Jest timeout configuration

This fix ensures that the comprehensive hot reload CRUD functionality tests can complete successfully in CI environments without timing out.