### PR TITLE
fix: pass baseDir parameter to file watcher callbacks

### DIFF
--- a/src/mcp/mcp-server.js
+++ b/src/mcp/mcp-server.js
@@ -465,12 +465,12 @@ class DynamicAPIMCPServer {
     this.promptsWatcher
       .on('add', (filePath) => {
         console.log(`🔌 MCP Server: New prompt file added: ${filePath}`);
-        this.loadPromptFromFile(filePath);
+        this.loadPromptFromFile(filePath, promptsPath);
         this.notifyPromptsChanged();
       })
       .on('change', (filePath) => {
         console.log(`🔌 MCP Server: Prompt file changed: ${filePath}`);
-        this.loadPromptFromFile(filePath);
+        this.loadPromptFromFile(filePath, promptsPath);
         this.notifyPromptsChanged();
       })
       .on('unlink', (filePath) => {
@@ -504,12 +504,12 @@ class DynamicAPIMCPServer {
     this.resourcesWatcher
       .on('add', (filePath) => {
         console.log(`🔌 MCP Server: New resource file added: ${filePath}`);
-        this.loadResourceFromFile(filePath);
+        this.loadResourceFromFile(filePath, resourcesPath);
         this.notifyResourcesChanged();
       })
       .on('change', (filePath) => {
         console.log(`🔌 MCP Server: Resource file changed: ${filePath}`);
-        this.loadResourceFromFile(filePath);
+        this.loadResourceFromFile(filePath, resourcesPath);
         this.notifyResourcesChanged();
       })
       .on('unlink', (filePath) => {


### PR DESCRIPTION
## 🔧 File Watcher BaseDir Parameter Fix

This PR fixes the CI test failures by ensuring file watcher callbacks pass the correct baseDir parameter to file loading methods.

### 🐛 Problem
The GitHub Actions CI was failing because the hot reload tests were not loading prompts and resources properly. The file watcher was detecting file changes, but the prompts/resources were not being loaded due to incorrect relative path calculation.

### ✅ Solution
- **Fixed file watcher callbacks**: Updated prompts and resources watchers to pass the correct  parameter
- **Correct relative path calculation**: Ensures nested files are processed with proper relative paths
- **Maintained functionality**: All hot reload CRUD operations work correctly

### 🧪 Testing
- All 12 hot reload CRUD tests pass locally ✅
- File watcher events now properly load prompts and resources
- Nested directory structures work correctly
- Error handling for invalid files works as expected

### 📁 Files Changed
- `src/mcp/mcp-server.js` - Updated file watcher callbacks to pass baseDir parameter

### 🔍 Technical Details
The issue was that the file watcher callbacks were calling:
- `this.loadPromptFromFile(filePath)` 
- `this.loadResourceFromFile(filePath)`

But these methods expect a `baseDir` parameter to calculate relative paths correctly. The fix ensures:
- `this.loadPromptFromFile(filePath, promptsPath)`
- `this.loadResourceFromFile(filePath, resourcesPath)`

This resolves the CI test failures and ensures hot reload functionality works properly in all environments.