### PR TITLE
Debug: Hot reload CI test failures

### DIFF
--- a/__tests__/mcp-hot-reload-crud.test.js
+++ b/__tests__/mcp-hot-reload-crud.test.js
@@ -12,7 +12,7 @@ const DynamicAPIMCPServer = require('../src/mcp/mcp-server');
 
 describe('MCP Server Hot Reload CRUD Operations', () => {
   // Increase timeout for CI environments
-  jest.setTimeout(15000);
+  jest.setTimeout(30000);
   
   let mcpServer;
   let tempDir;
@@ -100,9 +100,11 @@ Use this prompt to test hot reload functionality.`;
       while (mcpServer.prompts.size === 0 && retries < 20) {
         await new Promise(resolve => setTimeout(resolve, 200));
         retries++;
+        console.log(`Retry ${retries}: prompts.size = ${mcpServer.prompts.size}`);
       }
 
       // Check if prompt was loaded
+      console.log(`Final prompts.size = ${mcpServer.prompts.size}`);
       expect(mcpServer.prompts.size).toBeGreaterThan(0);
       
       const prompt = Array.from(mcpServer.prompts.values())[0];


### PR DESCRIPTION
This PR adds debugging information to help identify why hot reload tests pass locally but fail in CI.

Changes:
- Increased Jest timeout to 30 seconds for hot reload tests
- Added console logging to track retry attempts and final prompt count
- This will help debug the timing issues in CI environment

The tests are passing locally but failing in CI with the same error pattern. This debugging should provide more insight into what's happening during the test execution in the CI environment.