### PR TITLE
Fix: File watcher timing issue in hot reload tests

### DIFF
--- a/__tests__/mcp-hot-reload-crud.test.js
+++ b/__tests__/mcp-hot-reload-crud.test.js
@@ -39,6 +39,9 @@ describe('MCP Server Hot Reload CRUD Operations', () => {
     // Initialize and start the server
     await mcpServer.loadPromptsAndResourcesFromFilesystem();
     await mcpServer.run();
+    
+    // Wait for file watchers to be fully initialized
+    await new Promise(resolve => setTimeout(resolve, 1000));
   });
 
   afterAll(async () => {


### PR DESCRIPTION
This PR fixes the timing issue where the first hot reload test fails in CI but subsequent tests pass.

**Problem:**
- First test creates a file but it's not detected by the file watcher (prompts.size stays 0)
- Subsequent tests work fine, suggesting the file watcher needs time to initialize
- This only happens in CI, not locally

**Solution:**
- Add 1 second delay after server start to ensure file watchers are fully initialized
- This gives the file watcher time to set up before the first test runs

**Testing:**
- Test passes locally with this change
- Should resolve the CI test failure where the first test consistently fails