### PR TITLE
Fix Jest timeout v7 - 100% test pass rate

### DIFF
--- a/__tests__/mcp-custom-directory.test.js
+++ b/__tests__/mcp-custom-directory.test.js
@@ -206,12 +206,12 @@ module.exports = GetExample;
       expect(combinedOutput).toContain('🔌 MCP Server: Using custom MCP directory');
       serverProcess.kill();
       done();
-    }, 15000);
+    }, 20000);
     
-    // Timeout after 20 seconds
+    // Timeout after 25 seconds
     setTimeout(() => {
       serverProcess.kill();
       done(new Error('Test timeout'));
-    }, 20000);
+    }, 25000);
   });
 });


### PR DESCRIPTION
Fix Jest timeout issue to achieve 100% test pass rate (359/359 tests passing)