### PR TITLE
test: fix mcp-custom-directory test for cache manager changes

### DIFF
--- a/__tests__/mcp-custom-directory.test.js
+++ b/__tests__/mcp-custom-directory.test.js
@@ -76,7 +76,18 @@ This is a test resource from custom MCP directory.`;
     
     // Should have loaded the custom files
     expect(prompts.size).toBeGreaterThan(0);
-    expect(resources.size).toBeGreaterThan(0);
+    
+    // Resources are now loaded through cache manager when available, so check both static and cached
+    let totalResources = resources.size;
+    if (mcpServer.cacheManager) {
+      try {
+        const cachedResources = await mcpServer.cacheManager.getResources();
+        totalResources += cachedResources.length;
+      } catch (error) {
+        // Cache manager might not be available in test environment
+      }
+    }
+    expect(totalResources).toBeGreaterThan(0);
     
     // Check if our custom files are loaded
     let foundCustomPrompt = false;
@@ -91,6 +102,21 @@ This is a test resource from custom MCP directory.`;
     for (const [, resource] of resources) {
       if (resource.content && resource.content.includes('custom MCP directory')) {
         foundCustomResource = true;
+      }
+    }
+    
+    // Also check cached resources if cache manager is available
+    if (mcpServer.cacheManager && !foundCustomResource) {
+      try {
+        const cachedResources = await mcpServer.cacheManager.getResources();
+        for (const resource of cachedResources) {
+          if (resource.content && resource.content.includes('custom MCP directory')) {
+            foundCustomResource = true;
+            break;
+          }
+        }
+      } catch (error) {
+        // Cache manager might not be available in test environment
       }
     }
     


### PR DESCRIPTION
## Summary

This PR fixes the failing test in `mcp-custom-directory.test.js` that was caused by our resource duplication fix.

## Problem

The test was failing because our changes to prevent static resource loading when the cache manager is available caused the test to expect resources in the static `mcpServer.resources` map, but resources are now loaded through the cache manager instead.

## Solution

- Updated the test to check both static and cached resources
- Added logic to count resources from both sources when cache manager is available
- Updated resource content checking to also look in cached resources
- Maintained test coverage while adapting to the new resource loading behavior

## Changes

- Modified resource count assertion to check both static and cached resources
- Updated resource content verification to check cached resources when static resources don't contain the expected content
- Added error handling for cases where cache manager might not be available in test environment

## Testing

- Test now passes with the new resource loading behavior
- Maintains the same test coverage and validation logic
- Handles both scenarios: with and without cache manager