### PR TITLE
fix: resolve MCP undefined template error

### DIFF
--- a/src/mcp/mcp-server.js
+++ b/src/mcp/mcp-server.js
@@ -1246,8 +1246,8 @@ class DynamicAPIMCPServer {
       }
       
       // Process template with arguments if provided
-      let processedTemplate = prompt.template;
-      if (args && prompt.arguments) {
+      let processedTemplate = prompt.template || '';
+      if (args && prompt.arguments && processedTemplate) {
         prompt.arguments.forEach(arg => {
           if (args[arg.name] !== undefined) {
             const placeholder = new RegExp(`{{${arg.name}}}`, 'g');
@@ -1336,8 +1336,8 @@ class DynamicAPIMCPServer {
       }
       
       // Process template with arguments if provided and resource has parameters
-      let processedContent = resource.content;
-      if (args && resource.hasParameters && this.config.mcp.resources.enableTemplates) {
+      let processedContent = resource.content || '';
+      if (args && resource.hasParameters && this.config.mcp.resources.enableTemplates && processedContent) {
         resource.parameters.forEach(param => {
           if (args[param] !== undefined) {
             const placeholder = new RegExp(`{{${param}}}`, 'g');
@@ -1452,8 +1452,8 @@ class DynamicAPIMCPServer {
     }
     
     // Process template with arguments if provided
-    let processedTemplate = prompt.template;
-    if (args && prompt.arguments) {
+    let processedTemplate = prompt.template || '';
+    if (args && prompt.arguments && processedTemplate) {
       prompt.arguments.forEach(arg => {
         if (args[arg.name] !== undefined) {
           const placeholder = new RegExp(`{{${arg.name}}}`, 'g');
@@ -1685,8 +1685,8 @@ class DynamicAPIMCPServer {
     }
     
     // Process template with arguments if provided and resource has parameters
-    let processedContent = resource.content;
-    if (args && resource.hasParameters && this.config.mcp.resources.enableTemplates) {
+    let processedContent = resource.content || '';
+    if (args && resource.hasParameters && this.config.mcp.resources.enableTemplates && processedContent) {
       resource.parameters.forEach(param => {
         if (args[param] !== undefined) {
           const placeholder = new RegExp(`{{${param}}}`, 'g');


### PR DESCRIPTION
## Problem
The MCP server was throwing an error when clicking the Get Prompt button due to undefined template properties.

## Solution
- Added null/undefined checks for prompt.template and resource.content
- Added fallback to empty string for undefined templates/content
- Added additional checks to ensure template processing only occurs when content is truthy
- Fixed both WebSocket and HTTP MCP request handlers

## Changes Made
- processGetPrompt(): Added null check for prompt.template
- handleGetPrompt(): Added null check for prompt.template  
- processReadResource(): Added null check for resource.content
- handleReadResource(): Added null check for resource.content

## Testing
- All existing tests pass (358/358)
- No linting errors introduced
- Fix handles both WebSocket and HTTP MCP requests
- Fix applies to both prompts and resources

## Impact
This fix ensures the MCP server gracefully handles prompts and resources with undefined template/content properties, preventing internal server errors and improving reliability.