### PR TITLE
fix: resolve linting errors for CI/CD pipeline

### DIFF
--- a/__tests__/graceful-initialization.test.js
+++ b/__tests__/graceful-initialization.test.js
@@ -208,7 +208,6 @@ describe('Graceful API Initialization', () => {
       // Create a test API that fails initialization
       const fs = require('fs');
       const path = require('path');
-      const testApiPath = path.join(__dirname, 'temp-failing-api.js');
       
       const failingApiCode = `
 const BaseAPIEnhanced = require('../../src/lib/base-api-enhanced');
@@ -272,7 +271,7 @@ module.exports = FailingTestAPI;
         ).length;
         
         const overallStatus = failedAPIs === 0 ? 'healthy' : 
-                             healthyAPIs > 0 ? 'partial' : 'unhealthy';
+          healthyAPIs > 0 ? 'partial' : 'unhealthy';
         
         res.json({
           status: overallStatus,
@@ -531,7 +530,7 @@ module.exports = FailingTestAPI;
         ).length;
         
         const overallStatus = failedAPIs === 0 ? 'healthy' : 
-                             healthyAPIs > 0 ? 'partial' : 'unhealthy';
+          healthyAPIs > 0 ? 'partial' : 'unhealthy';
         
         res.json({
           status: overallStatus,

--- a/src/lib/base-api-enhanced.js
+++ b/src/lib/base-api-enhanced.js
@@ -452,8 +452,8 @@ class BaseAPIEnhanced extends BaseAPI {
                      status.components.logger;
     
     const message = isHealthy ? 'Service is healthy' : 
-                   status.initializationStatus === 'failed' ? 'Service initialization failed' :
-                   'Service is initializing';
+      status.initializationStatus === 'failed' ? 'Service initialization failed' :
+        'Service is initializing';
 
     return this.sendSuccessResponse(res, status, message, 
       isHealthy ? 200 : 503);

--- a/src/server.js
+++ b/src/server.js
@@ -54,7 +54,7 @@ app.get('/health', (req, res) => {
   ).length;
   
   const overallStatus = failedAPIs === 0 ? 'healthy' : 
-                       healthyAPIs > 0 ? 'partial' : 'unhealthy';
+    healthyAPIs > 0 ? 'partial' : 'unhealthy';
   
   res.json({
     status: overallStatus,


### PR DESCRIPTION
## 🔧 Linting Fixes

This PR resolves all linting errors that were causing the CI/CD pipeline to fail.

### 🐛 Issues Fixed

- **Indentation errors** in graceful-initialization.test.js
- **Indentation errors** in base-api-enhanced.js  
- **Indentation errors** in server.js
- **Unused variable** testApiPath removed

### ✅ Results

- All linting errors resolved
- CI/CD pipeline should now pass
- Ready for semantic release

### 🚀 Impact

This fix enables the automatic patch release for the graceful API initialization feature (PR #175) to proceed successfully.