### PR TITLE
feat: Update default ports to 8887/8888 and remove CLI port arguments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@
 
 # Main API server configuration
 EASY_MCP_SERVER_HOST=0.0.0.0
-EASY_MCP_SERVER_PORT=3000
+EASY_MCP_SERVER_PORT=8887
 
 # API path (optional - defaults to ./api)
 EASY_MCP_SERVER_API_PATH=./api
@@ -21,7 +21,7 @@ NODE_ENV=development
 
 # MCP server configuration
 EASY_MCP_SERVER_MCP_HOST=0.0.0.0
-EASY_MCP_SERVER_MCP_PORT=3001
+EASY_MCP_SERVER_MCP_PORT=8888
 
 # Enable/disable MCP server (set to 'false' to disable)
 EASY_MCP_SERVER_MCP_ENABLED=true
@@ -117,8 +117,8 @@ OPENAI_API_KEY=your-openai-api-key-here
 
 # Example: Production environment
 # NODE_ENV=production
-# EASY_MCP_SERVER_PORT=8080
-# EASY_MCP_SERVER_MCP_PORT=8081
+# EASY_MCP_SERVER_PORT=8887
+# EASY_MCP_SERVER_MCP_PORT=8888
 
 # Example: Custom CORS settings
 # EASY_MCP_SERVER_CORS_ORIGIN=https://yourdomain.com

--- a/Agent.md
+++ b/Agent.md
@@ -189,7 +189,7 @@ class AgentErrorHandler extends BaseAPI {
 
 ### Environment Variables
 ```bash
-AGENT_PORT=8888                    # Agent MCP server port
+EASY_MCP_SERVER_MCP_PORT=8888     # Agent MCP server port
 AGENT_SESSION_TIMEOUT=3600         # Session timeout in seconds
 AGENT_RATE_LIMIT=100               # Requests per minute
 ```
@@ -315,7 +315,7 @@ DEBUG=agent:* easy-mcp-server
 
 ### Health Check
 ```bash
-curl -H "X-Agent-ID: test-agent" http://localhost:8888/health
+curl -H "X-Agent-ID: test-agent" http://localhost:${EASY_MCP_SERVER_MCP_PORT:-8888}/health
 ```
 
 ---

--- a/Agent.md
+++ b/Agent.md
@@ -189,7 +189,7 @@ class AgentErrorHandler extends BaseAPI {
 
 ### Environment Variables
 ```bash
-AGENT_PORT=3001                    # Agent MCP server port
+AGENT_PORT=8888                    # Agent MCP server port
 AGENT_SESSION_TIMEOUT=3600         # Session timeout in seconds
 AGENT_RATE_LIMIT=100               # Requests per minute
 ```
@@ -315,7 +315,7 @@ DEBUG=agent:* easy-mcp-server
 
 ### Health Check
 ```bash
-curl -H "X-Agent-ID: test-agent" http://localhost:3001/health
+curl -H "X-Agent-ID: test-agent" http://localhost:8888/health
 ```
 
 ---

--- a/LLM.txt
+++ b/LLM.txt
@@ -291,7 +291,7 @@ if (!body.text || typeof body.text !== 'string') {
 - `GET /health` - Health check endpoint
 
 ### WebSocket Support
-- `ws://localhost:3001` - WebSocket MCP server
+- `ws://localhost:8888` - WebSocket MCP server
 - Real-time tool updates
 - Bidirectional communication
 
@@ -299,7 +299,7 @@ if (!body.text || typeof body.text !== 'string') {
 
 ### Environment Variables
 ```bash
-MCP_PORT=3001                    # MCP server port
+MCP_PORT=8888                    # MCP server port
 OPENAI_API_KEY=your-key-here     # OpenAI API key
 REDIS_URL=redis://localhost:6379 # Redis for caching
 NODE_ENV=production              # Environment
@@ -308,7 +308,7 @@ NODE_ENV=production              # Environment
 ### MCP Server Options
 ```javascript
 const mcpServer = new DynamicAPIMCPServer({
-  port: 3001,
+  port: 8888,
   host: '0.0.0.0',
   enableWebSocket: true,
   enableSSE: true
@@ -366,7 +366,7 @@ DEBUG=* easy-mcp-server
 
 ### Health Check
 ```bash
-curl http://localhost:3001/health
+curl http://localhost:8888/health
 ```
 
 ## Performance Considerations

--- a/LLM.txt
+++ b/LLM.txt
@@ -291,7 +291,7 @@ if (!body.text || typeof body.text !== 'string') {
 - `GET /health` - Health check endpoint
 
 ### WebSocket Support
-- `ws://localhost:8888` - WebSocket MCP server
+- `ws://localhost:${EASY_MCP_SERVER_MCP_PORT:-8888}` - WebSocket MCP server
 - Real-time tool updates
 - Bidirectional communication
 
@@ -299,7 +299,7 @@ if (!body.text || typeof body.text !== 'string') {
 
 ### Environment Variables
 ```bash
-MCP_PORT=8888                    # MCP server port
+EASY_MCP_SERVER_MCP_PORT=8888    # MCP server port
 OPENAI_API_KEY=your-key-here     # OpenAI API key
 REDIS_URL=redis://localhost:6379 # Redis for caching
 NODE_ENV=production              # Environment
@@ -308,7 +308,7 @@ NODE_ENV=production              # Environment
 ### MCP Server Options
 ```javascript
 const mcpServer = new DynamicAPIMCPServer({
-  port: 8888,
+  port: process.env.EASY_MCP_SERVER_MCP_PORT || 8888,
   host: '0.0.0.0',
   enableWebSocket: true,
   enableSSE: true
@@ -366,7 +366,7 @@ DEBUG=* easy-mcp-server
 
 ### Health Check
 ```bash
-curl http://localhost:8888/health
+curl http://localhost:${EASY_MCP_SERVER_MCP_PORT:-8888}/health
 ```
 
 ## Performance Considerations

--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ module.exports = GetUsers;
 npx easy-mcp-server
 
 # With custom ports
-npx easy-mcp-server --port 8080 --mcp-port 8081
-npx easy-mcp-server --api-port 8080 --mcp-port 8081
+npx easy-mcp-server --port 8887 --mcp-port 8888
+npx easy-mcp-server --api-port 8887 --mcp-port 8888
 
 # Using environment variables (recommended)
-EASY_MCP_SERVER_PORT=8080 EASY_MCP_SERVER_MCP_PORT=8081 npx easy-mcp-server
+EASY_MCP_SERVER_PORT=8887 EASY_MCP_SERVER_MCP_PORT=8888 npx easy-mcp-server
 
 ```
 
@@ -415,11 +415,11 @@ NODE_ENV=development                         # Environment
 ### CLI Options
 ```bash
 # Port configuration
-easy-mcp-server --port 8080 --mcp-port 8081
-easy-mcp-server --api-port 8080 --mcp-port 8081
+easy-mcp-server --port 8887 --mcp-port 8888
+easy-mcp-server --api-port 8887 --mcp-port 8888
 
 # Environment variables
-EASY_MCP_SERVER_PORT=8080 EASY_MCP_SERVER_MCP_PORT=8081 easy-mcp-server
+EASY_MCP_SERVER_PORT=8887 EASY_MCP_SERVER_MCP_PORT=8888 easy-mcp-server
 
 # Help
 easy-mcp-server --help
@@ -430,18 +430,18 @@ The server supports multiple ways to configure ports:
 
 **1. Command Line Arguments:**
 ```bash
-npx easy-mcp-server --port 8080 --mcp-port 8081
-npx easy-mcp-server --api-port 8080 --mcp-port 8081
+npx easy-mcp-server --port 8887 --mcp-port 8888
+npx easy-mcp-server --api-port 8887 --mcp-port 8888
 ```
 
 **2. Environment Variables:**
 ```bash
 # In .env file (recommended)
-EASY_MCP_SERVER_PORT=8080
-EASY_MCP_SERVER_MCP_PORT=8081
+EASY_MCP_SERVER_PORT=8887
+EASY_MCP_SERVER_MCP_PORT=8888
 
 # Or inline (recommended)
-EASY_MCP_SERVER_PORT=8080 EASY_MCP_SERVER_MCP_PORT=8081 npx easy-mcp-server
+EASY_MCP_SERVER_PORT=8887 EASY_MCP_SERVER_MCP_PORT=8888 npx easy-mcp-server
 ```
 
 **3. Priority Order:**

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ EASY_MCP_SERVER_PORT=8887 EASY_MCP_SERVER_MCP_PORT=8888 npx easy-mcp-server
 ```
 
 **3. Priority Order:**
-1. CLI arguments (`--port`/`--api-port`, `--mcp-port`)
+1. CLI arguments (`--port`)
 2. Environment variables (`EASY_MCP_SERVER_PORT`, `EASY_MCP_SERVER_MCP_PORT`) - **Recommended**
 3. Default values (8887 for REST API, 8888 for MCP)
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ EASY_MCP_SERVER_PORT=8080 EASY_MCP_SERVER_MCP_PORT=8081 npx easy-mcp-server
 - 📊 **Error Reporting**: Clear error messages with helpful suggestions
 
 **Access Points:**
-- 🌐 **REST API**: http://localhost:8887
-- 🤖 **MCP Server**: http://localhost:8888  
+- 🌐 **REST API**: http://localhost:8887 (default)
+- 🤖 **MCP Server**: http://localhost:8888 (default)
 - 📚 **OpenAPI**: http://localhost:8887/openapi.json
 - 🔍 **Swagger UI**: http://localhost:8887/docs
 - 📁 **Static Files**: http://localhost:8887/ (serves from `public/` directory)

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ NODE_ENV=development                         # Environment
 ### CLI Options
 ```bash
 # Port configuration
-easy-mcp-server --port 8887
+EASY_MCP_SERVER_PORT=8887 easy-mcp-server
 
 # Environment variables
 EASY_MCP_SERVER_PORT=8887 EASY_MCP_SERVER_MCP_PORT=8888 easy-mcp-server
@@ -428,7 +428,7 @@ The server supports multiple ways to configure ports:
 
 **1. Command Line Arguments:**
 ```bash
-npx easy-mcp-server --port 8887
+npx EASY_MCP_SERVER_PORT=8887 easy-mcp-server
 ```
 
 **2. Environment Variables:**

--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ EASY_MCP_SERVER_PORT=8080 EASY_MCP_SERVER_MCP_PORT=8081 npx easy-mcp-server
 - 📊 **Error Reporting**: Clear error messages with helpful suggestions
 
 **Access Points:**
-- 🌐 **REST API**: http://localhost:3000
-- 🤖 **MCP Server**: http://localhost:3001  
-- 📚 **OpenAPI**: http://localhost:3000/openapi.json
-- 🔍 **Swagger UI**: http://localhost:3000/docs
-- 📁 **Static Files**: http://localhost:3000/ (serves from `public/` directory)
+- 🌐 **REST API**: http://localhost:8887
+- 🤖 **MCP Server**: http://localhost:8888  
+- 📚 **OpenAPI**: http://localhost:8887/openapi.json
+- 🔍 **Swagger UI**: http://localhost:8887/docs
+- 📁 **Static Files**: http://localhost:8887/ (serves from `public/` directory)
 
 ### 4. Add MCP Features (AI Integration)
 ```bash
@@ -386,8 +386,8 @@ All project-specific environment variables use the `EASY_MCP_SERVER_` prefix for
 
 ```bash
 # .env
-EASY_MCP_SERVER_PORT=3000                    # REST API port
-EASY_MCP_SERVER_MCP_PORT=3001               # MCP server port
+EASY_MCP_SERVER_PORT=8887                    # REST API port
+EASY_MCP_SERVER_MCP_PORT=8888               # MCP server port
 EASY_MCP_SERVER_HOST=0.0.0.0                # REST API host
 EASY_MCP_SERVER_MCP_HOST=0.0.0.0            # MCP server host
 EASY_MCP_SERVER_MCP_BASE_PATH=./mcp         # MCP base directory

--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ module.exports = GetUsers;
 npx easy-mcp-server
 
 # With custom ports
-npx easy-mcp-server --port 8887 --mcp-port 8888
-npx easy-mcp-server --api-port 8887 --mcp-port 8888
+npx easy-mcp-server --port 8887
 
 # Using environment variables (recommended)
 EASY_MCP_SERVER_PORT=8887 EASY_MCP_SERVER_MCP_PORT=8888 npx easy-mcp-server
@@ -415,8 +414,7 @@ NODE_ENV=development                         # Environment
 ### CLI Options
 ```bash
 # Port configuration
-easy-mcp-server --port 8887 --mcp-port 8888
-easy-mcp-server --api-port 8887 --mcp-port 8888
+easy-mcp-server --port 8887
 
 # Environment variables
 EASY_MCP_SERVER_PORT=8887 EASY_MCP_SERVER_MCP_PORT=8888 easy-mcp-server
@@ -430,8 +428,7 @@ The server supports multiple ways to configure ports:
 
 **1. Command Line Arguments:**
 ```bash
-npx easy-mcp-server --port 8887 --mcp-port 8888
-npx easy-mcp-server --api-port 8887 --mcp-port 8888
+npx easy-mcp-server --port 8887
 ```
 
 **2. Environment Variables:**

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ EASY_MCP_SERVER_PORT=8080 EASY_MCP_SERVER_MCP_PORT=8081 npx easy-mcp-server
 **3. Priority Order:**
 1. CLI arguments (`--port`/`--api-port`, `--mcp-port`)
 2. Environment variables (`EASY_MCP_SERVER_PORT`, `EASY_MCP_SERVER_MCP_PORT`) - **Recommended**
-3. Default values (3000 for REST API, 3001 for MCP)
+3. Default values (8887 for REST API, 8888 for MCP)
 
 ### Auto npm Install
 The server automatically runs `npm install` before starting if a `package.json` file is found in your project directory:
@@ -545,7 +545,7 @@ The framework includes **graceful initialization** to prevent server crashes whe
 **Retry Failed APIs:**
 ```bash
 # Retry a specific API
-curl -X POST http://localhost:3000/admin/retry-initialization \
+curl -X POST http://localhost:${EASY_MCP_SERVER_PORT:-8887}/admin/retry-initialization \
   -H "Content-Type: application/json" \
   -d '{"api": "opensearch-api"}'
 ```

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ module.exports = GetUsers;
 # Basic usage
 npx easy-mcp-server
 
-# With custom ports
-npx easy-mcp-server --port 8887
+# With custom ports (using environment variables)
+EASY_MCP_SERVER_PORT=8887 npx easy-mcp-server
 
 # Using environment variables (recommended)
 EASY_MCP_SERVER_PORT=8887 EASY_MCP_SERVER_MCP_PORT=8888 npx easy-mcp-server
@@ -442,9 +442,8 @@ EASY_MCP_SERVER_PORT=8887 EASY_MCP_SERVER_MCP_PORT=8888 npx easy-mcp-server
 ```
 
 **3. Priority Order:**
-1. CLI arguments (`--port`)
-2. Environment variables (`EASY_MCP_SERVER_PORT`, `EASY_MCP_SERVER_MCP_PORT`) - **Recommended**
-3. Default values (8887 for REST API, 8888 for MCP)
+1. Environment variables (`EASY_MCP_SERVER_PORT`, `EASY_MCP_SERVER_MCP_PORT`) - **Recommended**
+2. Default values (8887 for REST API, 8888 for MCP)
 
 ### Auto npm Install
 The server automatically runs `npm install` before starting if a `package.json` file is found in your project directory:

--- a/__tests__/custom-content-troubleshooting.test.js
+++ b/__tests__/custom-content-troubleshooting.test.js
@@ -23,7 +23,7 @@ describe('Custom Content Troubleshooting', () => {
     await fs.mkdir(customResourcesDir, { recursive: true });
 
     // Initialize server with custom directories
-    server = new DynamicAPIMCPServer('0.0.0.0', 3001, {
+    server = new DynamicAPIMCPServer('0.0.0.0', 8888, {
       prompts: {
         enabled: true,
         directory: customPromptsDir,

--- a/__tests__/env-hot-reload.test.js
+++ b/__tests__/env-hot-reload.test.js
@@ -40,7 +40,7 @@ describe('Environment Hot Reload', () => {
   test('should detect .env file changes and reload environment variables', (done) => {
     // Create initial .env file
     const envFile = path.join(tempDir, '.env');
-    fs.writeFileSync(envFile, 'TEST_VAR=initial_value\nEASY_MCP_SERVER_PORT=3000\n');
+    fs.writeFileSync(envFile, 'TEST_VAR=initial_value\nEASY_MCP_SERVER_PORT=8887\n');
 
     // Create a simple API file
     const apiDir = path.join(tempDir, 'api');
@@ -86,7 +86,7 @@ module.exports = router;
         // Wait a bit for server to fully start
         setTimeout(() => {
           // Modify .env file
-          fs.writeFileSync(envFile, 'TEST_VAR=updated_value\nEASY_MCP_SERVER_PORT=3001\n');
+          fs.writeFileSync(envFile, 'TEST_VAR=updated_value\nEASY_MCP_SERVER_PORT=8888\n');
         }, 2000);
       }
       

--- a/__tests__/env-loading.test.js
+++ b/__tests__/env-loading.test.js
@@ -85,9 +85,9 @@ module.exports = TestAPI;
 
   test('should load multiple .env files in correct order', (done) => {
     // Create multiple .env files
-    fs.writeFileSync(path.join(tempDir, '.env'), 'BASE_VAR=base\nPORT=3000');
-    fs.writeFileSync(path.join(tempDir, '.env.development'), 'DEV_VAR=development\nPORT=3001');
-    fs.writeFileSync(path.join(tempDir, '.env.local'), 'LOCAL_VAR=local\nPORT=3002');
+    fs.writeFileSync(path.join(tempDir, '.env'), 'BASE_VAR=base\nEASY_MCP_SERVER_PORT=8887');
+    fs.writeFileSync(path.join(tempDir, '.env.development'), 'DEV_VAR=development\nEASY_MCP_SERVER_PORT=8888');
+    fs.writeFileSync(path.join(tempDir, '.env.local'), 'LOCAL_VAR=local\nEASY_MCP_SERVER_PORT=8889');
 
     // Create a simple API file
     const apiDir = path.join(tempDir, 'api');

--- a/__tests__/ipv6-binding.test.js
+++ b/__tests__/ipv6-binding.test.js
@@ -89,10 +89,10 @@ describe('IPv6 Binding Fix for Kubernetes Compatibility', () => {
   });
 
   test('MCP server can still bind to specific interfaces when needed', () => {
-    const localhostServer = new DynamicAPIMCPServer('localhost', 3001);
+    const localhostServer = new DynamicAPIMCPServer('localhost', 8888);
     expect(localhostServer.host).toBe('localhost');
     
-    const customServer = new DynamicAPIMCPServer('192.168.1.100', 3001);
+    const customServer = new DynamicAPIMCPServer('192.168.1.100', 8888);
     expect(customServer.host).toBe('192.168.1.100');
   });
 

--- a/__tests__/mcp-custom-resources-prompts.test.js
+++ b/__tests__/mcp-custom-resources-prompts.test.js
@@ -166,7 +166,7 @@ paths:
           uri: 'resource://template-config.json',
           arguments: {
             service_name: 'MyAPI',
-            port: '3000',
+            port: '8887',
             environment: 'production',
             feature1: 'authentication',
             feature2: 'caching'
@@ -185,7 +185,7 @@ paths:
       const processedData = JSON.parse(content.text);
       expect(processedData.name).toBe('MyAPI Configuration');
       expect(processedData.description).toBe('Configuration for MyAPI service');
-      expect(processedData.port).toBe('3000');
+      expect(processedData.port).toBe('8887');
       expect(processedData.environment).toBe('production');
       expect(processedData.features).toEqual(['authentication', 'caching']);
     });

--- a/__tests__/mcp.test.js
+++ b/__tests__/mcp.test.js
@@ -173,15 +173,15 @@ describe('MCP (Model Context Protocol) Support', () => {
     expect(mcpServerDefault.host).toBe('0.0.0.0');
     
     // Test explicit binding to all interfaces
-    const mcpServerAllInterfaces = new DynamicAPIMCPServer('0.0.0.0', 3001);
+    const mcpServerAllInterfaces = new DynamicAPIMCPServer('0.0.0.0', 8888);
     expect(mcpServerAllInterfaces.host).toBe('0.0.0.0');
     
     // Test that localhost still works when explicitly specified
-    const mcpServerLocalhost = new DynamicAPIMCPServer('localhost', 3001);
+    const mcpServerLocalhost = new DynamicAPIMCPServer('localhost', 8888);
     expect(mcpServerLocalhost.host).toBe('localhost');
     
     // Test that custom host still works
-    const mcpServerCustom = new DynamicAPIMCPServer('192.168.1.100', 3001);
+    const mcpServerCustom = new DynamicAPIMCPServer('192.168.1.100', 8888);
     expect(mcpServerCustom.host).toBe('192.168.1.100');
   });
 
@@ -203,7 +203,7 @@ describe('MCP (Model Context Protocol) Support', () => {
       }
     };
     
-    const mcpServer = new DynamicAPIMCPServer('0.0.0.0', 3001, customOptions);
+    const mcpServer = new DynamicAPIMCPServer('0.0.0.0', 8888, customOptions);
     
     // Should use custom base path
     expect(mcpServer.config.mcp.basePath).toBe('./custom-mcp');
@@ -225,7 +225,7 @@ describe('MCP (Model Context Protocol) Support', () => {
       }
     };
     
-    const mcpServer = new DynamicAPIMCPServer('0.0.0.0', 3001, customOptions);
+    const mcpServer = new DynamicAPIMCPServer('0.0.0.0', 8888, customOptions);
     
     // Should use custom base path and custom subdirectories
     expect(mcpServer.config.mcp.basePath).toBe('./custom-mcp');
@@ -241,7 +241,7 @@ describe('MCP (Model Context Protocol) Support', () => {
       }
     };
     
-    const mcpServer = new DynamicAPIMCPServer('0.0.0.0', 3001, customOptions);
+    const mcpServer = new DynamicAPIMCPServer('0.0.0.0', 8888, customOptions);
     
     // Cache manager should use the resolved base path (package directory when custom doesn't exist)
     expect(mcpServer.cacheManager.basePath).toContain('mcp');
@@ -256,7 +256,7 @@ describe('MCP (Model Context Protocol) Support', () => {
       // No custom prompts or resources directories
     };
     
-    const mcpServer = new DynamicAPIMCPServer('0.0.0.0', 3001, customOptions);
+    const mcpServer = new DynamicAPIMCPServer('0.0.0.0', 8888, customOptions);
     
     // Should use custom base path with default subdirectories
     expect(mcpServer.config.mcp.basePath).toBe('./custom-mcp');

--- a/__tests__/port-configuration.test.js
+++ b/__tests__/port-configuration.test.js
@@ -90,8 +90,8 @@ module.exports = TestAPI;
 `;
     fs.writeFileSync(apiFile, apiContent);
 
-    // Start the server with custom ports
-    const serverProcess = spawn('node', ['../../bin/easy-mcp-server.js', '--port', '8887'], {
+    // Start the server with default ports
+    const serverProcess = spawn('node', ['../../bin/easy-mcp-server.js'], {
       stdio: 'pipe',
       cwd: tempDir
     });
@@ -266,14 +266,14 @@ module.exports = TestAPI;
 `;
     fs.writeFileSync(apiFile, apiContent);
 
-    // Start the server with CLI args (should override env vars)
-    const serverProcess = spawn('node', ['../../bin/easy-mcp-server.js', '--port', '9997'], {
+    // Start the server with environment variables
+    const serverProcess = spawn('node', ['../../bin/easy-mcp-server.js'], {
       stdio: 'pipe',
       cwd: tempDir,
       env: {
         ...process.env,
-        PORT: '8887',  // This should be overridden by CLI
-        MCP_PORT: '8888'  // This should be overridden by CLI
+        EASY_MCP_SERVER_PORT: '9997',
+        EASY_MCP_SERVER_MCP_PORT: '9998'
       }
     });
 

--- a/__tests__/port-configuration.test.js
+++ b/__tests__/port-configuration.test.js
@@ -91,7 +91,7 @@ module.exports = TestAPI;
     fs.writeFileSync(apiFile, apiContent);
 
     // Start the server with custom ports
-    const serverProcess = spawn('node', ['../../bin/easy-mcp-server.js', '--api-port', '8080', '--mcp-port', '8081'], {
+    const serverProcess = spawn('node', ['../../bin/easy-mcp-server.js', '--api-port', '8887', '--mcp-port', '8888'], {
       stdio: 'pipe',
       cwd: tempDir
     });
@@ -142,8 +142,8 @@ module.exports = TestAPI;
 
     // Create .env file with port configuration
     const envContent = `
-EASY_MCP_SERVER_PORT=8080
-EASY_MCP_SERVER_MCP_PORT=8081
+EASY_MCP_SERVER_PORT=8887
+EASY_MCP_SERVER_MCP_PORT=8888
 `;
     fs.writeFileSync(path.join(tempDir, '.env'), envContent);
 
@@ -153,8 +153,8 @@ EASY_MCP_SERVER_MCP_PORT=8081
       cwd: tempDir,
       env: {
         ...process.env,
-        EASY_MCP_SERVER_PORT: '8080',
-        EASY_MCP_SERVER_MCP_PORT: '8081'
+        EASY_MCP_SERVER_PORT: '8887',
+        EASY_MCP_SERVER_MCP_PORT: '8888'
       }
     });
 
@@ -205,8 +205,8 @@ module.exports = TestAPI;
 
     // Create .env file with fallback port configuration
     const envContent = `
-PORT=8080
-MCP_PORT=8081
+PORT=8887
+MCP_PORT=8888
 `;
     fs.writeFileSync(path.join(tempDir, '.env'), envContent);
 
@@ -216,8 +216,8 @@ MCP_PORT=8081
       cwd: tempDir,
       env: {
         ...process.env,
-        PORT: '8080',
-        MCP_PORT: '8081'
+        PORT: '8887',
+        MCP_PORT: '8888'
       }
     });
 
@@ -267,13 +267,13 @@ module.exports = TestAPI;
     fs.writeFileSync(apiFile, apiContent);
 
     // Start the server with CLI args (should override env vars)
-    const serverProcess = spawn('node', ['../../bin/easy-mcp-server.js', '--api-port', '9090', '--mcp-port', '9091'], {
+    const serverProcess = spawn('node', ['../../bin/easy-mcp-server.js', '--api-port', '9997', '--mcp-port', '9998'], {
       stdio: 'pipe',
       cwd: tempDir,
       env: {
         ...process.env,
-        PORT: '8080',  // This should be overridden by CLI
-        MCP_PORT: '8081'  // This should be overridden by CLI
+        PORT: '8887',  // This should be overridden by CLI
+        MCP_PORT: '8888'  // This should be overridden by CLI
       }
     });
 

--- a/__tests__/port-configuration.test.js
+++ b/__tests__/port-configuration.test.js
@@ -91,7 +91,7 @@ module.exports = TestAPI;
     fs.writeFileSync(apiFile, apiContent);
 
     // Start the server with custom ports
-    const serverProcess = spawn('node', ['../../bin/easy-mcp-server.js', '--api-port', '8887', '--mcp-port', '8888'], {
+    const serverProcess = spawn('node', ['../../bin/easy-mcp-server.js', '--port', '8887'], {
       stdio: 'pipe',
       cwd: tempDir
     });
@@ -267,7 +267,7 @@ module.exports = TestAPI;
     fs.writeFileSync(apiFile, apiContent);
 
     // Start the server with CLI args (should override env vars)
-    const serverProcess = spawn('node', ['../../bin/easy-mcp-server.js', '--api-port', '9997', '--mcp-port', '9998'], {
+    const serverProcess = spawn('node', ['../../bin/easy-mcp-server.js', '--port', '9997'], {
       stdio: 'pipe',
       cwd: tempDir,
       env: {

--- a/bin/easy-mcp-server.js
+++ b/bin/easy-mcp-server.js
@@ -447,16 +447,16 @@ describe('Easy MCP Server', () => {
    3. easy-mcp-server
 
 📚 Your server will be available at:
-   - Server: http://localhost:8887
-   - API Docs: http://localhost:8887/docs
-   - Health Check: http://localhost:8887/health
-   - OpenAPI Spec: http://localhost:8887/openapi.json
-   - API Info: http://localhost:8887/api-info
+   - Server: http://localhost:${config.port}
+   - API Docs: http://localhost:${config.port}/docs
+   - Health Check: http://localhost:${config.port}/health
+   - OpenAPI Spec: http://localhost:${config.port}/openapi.json
+   - API Info: http://localhost:${config.port}/api-info
 
 🔌 MCP (Model Context Protocol) Integration:
-   - MCP Server: http://localhost:8888
-   - MCP Tools: http://localhost:8887/mcp/tools
-   - MCP Schema: http://localhost:8887/mcp/schema
+   - MCP Server: http://localhost:${config.mcpPort}
+   - MCP Tools: http://localhost:${config.port}/mcp/tools
+   - MCP Schema: http://localhost:${config.port}/mcp/schema
    - Transport Types: Streamable HTTP, Server-Sent Events (SSE)
    - MCP Endpoints: GET /sse, POST /mcp, POST / (StreamableHttp)
 

--- a/bin/easy-mcp-server.js
+++ b/bin/easy-mcp-server.js
@@ -35,8 +35,6 @@ Commands:
 
 Options:
   --port <number>        Set the REST API server port (default: 8887)
-  --api-port <number>    Set the REST API server port (alternative to --port)
-  --mcp-port <number>    Set the MCP server port (default: 8888)
 
 Environment Variables:
   EASY_MCP_SERVER_PORT   REST API server port
@@ -61,10 +59,9 @@ Server Starting Behavior:
 Examples:
   easy-mcp-server                    # Start server (custom or auto)
   easy-mcp-server --port 8887       # Start server on port 8887
-  easy-mcp-server --mcp-port 8888   # Start MCP server on port 8888
   easy-mcp-server init               # Create new project
   npx easy-mcp-server                # Run without installation
-  npx easy-mcp-server --port 8888   # Run with custom port
+  npx easy-mcp-server --port 8887   # Run with custom port
 
 For more information, visit: https://github.com/easynet-world/7134-easy-mcp-server
 `);
@@ -579,17 +576,6 @@ function parsePortArguments() {
     config.port = parseInt(args[portIndex + 1]);
   }
   
-  // Parse --mcp-port argument
-  const mcpPortIndex = args.indexOf('--mcp-port');
-  if (mcpPortIndex !== -1 && args[mcpPortIndex + 1]) {
-    config.mcpPort = parseInt(args[mcpPortIndex + 1]);
-  }
-  
-  // Parse --api-port argument (alternative to --port)
-  const apiPortIndex = args.indexOf('--api-port');
-  if (apiPortIndex !== -1 && args[apiPortIndex + 1]) {
-    config.port = parseInt(args[apiPortIndex + 1]);
-  }
   
   return config;
 }

--- a/bin/easy-mcp-server.js
+++ b/bin/easy-mcp-server.js
@@ -64,7 +64,7 @@ Examples:
   easy-mcp-server --mcp-port 8081   # Start MCP server on port 8081
   easy-mcp-server init               # Create new project
   npx easy-mcp-server                # Run without installation
-  npx easy-mcp-server --port 3001   # Run with custom port
+  npx easy-mcp-server --port 8888   # Run with custom port
 
 For more information, visit: https://github.com/easynet-world/7134-easy-mcp-server
 `);
@@ -298,7 +298,7 @@ module.exports = GetExample;
 ## Environment Variables
 
 Copy \`.env.example\` to \`.env\` and configure:
-- \`PORT\`: Server port (default: 3000)
+- \`EASY_MCP_SERVER_PORT\`: Server port (default: 8887)
 - \`NODE_ENV\`: Environment (development/production)
 - \`EASY_MCP_SERVER_CORS_ORIGIN\`: CORS origin
 - \`EASY_MCP_SERVER_CORS_METHODS\`: Allowed HTTP methods

--- a/bin/easy-mcp-server.js
+++ b/bin/easy-mcp-server.js
@@ -34,9 +34,9 @@ Commands:
   --help  Show this help message
 
 Options:
-  --port <number>        Set the REST API server port (default: 3000)
+  --port <number>        Set the REST API server port (default: 8887)
   --api-port <number>    Set the REST API server port (alternative to --port)
-  --mcp-port <number>    Set the MCP server port (default: 3001)
+  --mcp-port <number>    Set the MCP server port (default: 8888)
 
 Environment Variables:
   EASY_MCP_SERVER_PORT   REST API server port
@@ -151,8 +151,8 @@ module.exports = {
   
   // Create .env file
   const envFile = `# Easy MCP Server Configuration
-EASY_MCP_SERVER_PORT=3000
-EASY_MCP_SERVER_MCP_PORT=3001
+EASY_MCP_SERVER_PORT=8887
+EASY_MCP_SERVER_MCP_PORT=8888
 EASY_MCP_SERVER_HOST=0.0.0.0
 EASY_MCP_SERVER_MCP_HOST=0.0.0.0
 NODE_ENV=development
@@ -447,16 +447,16 @@ describe('Easy MCP Server', () => {
    3. easy-mcp-server
 
 📚 Your server will be available at:
-   - Server: http://localhost:3000
-   - API Docs: http://localhost:3000/docs
-   - Health Check: http://localhost:3000/health
-   - OpenAPI Spec: http://localhost:3000/openapi.json
-   - API Info: http://localhost:3000/api-info
+   - Server: http://localhost:8887
+   - API Docs: http://localhost:8887/docs
+   - Health Check: http://localhost:8887/health
+   - OpenAPI Spec: http://localhost:8887/openapi.json
+   - API Info: http://localhost:8887/api-info
 
 🔌 MCP (Model Context Protocol) Integration:
-   - MCP Server: http://localhost:3001
-   - MCP Tools: http://localhost:3000/mcp/tools
-   - MCP Schema: http://localhost:3000/mcp/schema
+   - MCP Server: http://localhost:8888
+   - MCP Tools: http://localhost:8887/mcp/tools
+   - MCP Schema: http://localhost:8887/mcp/schema
    - Transport Types: Streamable HTTP, Server-Sent Events (SSE)
    - MCP Endpoints: GET /sse, POST /mcp, POST / (StreamableHttp)
 
@@ -569,8 +569,8 @@ async function autoInstallDependencies() {
 function parsePortArguments() {
   const args = process.argv.slice(2);
   const config = {
-    port: process.env.EASY_MCP_SERVER_PORT || 3000,
-    mcpPort: process.env.EASY_MCP_SERVER_MCP_PORT || 3001
+    port: process.env.EASY_MCP_SERVER_PORT || 8887,
+    mcpPort: process.env.EASY_MCP_SERVER_MCP_PORT || 8888
   };
   
   // Parse --port argument

--- a/bin/easy-mcp-server.js
+++ b/bin/easy-mcp-server.js
@@ -34,7 +34,7 @@ Commands:
   --help  Show this help message
 
 Options:
-  --port <number>        Set the REST API server port (default: 8887)
+  (No CLI options - use environment variables)
 
 Environment Variables:
   EASY_MCP_SERVER_PORT   REST API server port
@@ -58,10 +58,11 @@ Server Starting Behavior:
 
 Examples:
   easy-mcp-server                    # Start server (custom or auto)
-  easy-mcp-server --port 8887       # Start server on port 8887
   easy-mcp-server init               # Create new project
   npx easy-mcp-server                # Run without installation
-  npx easy-mcp-server --port 8887   # Run with custom port
+  
+  # Using environment variables (recommended)
+  EASY_MCP_SERVER_PORT=8887 EASY_MCP_SERVER_MCP_PORT=8888 easy-mcp-server
 
 For more information, visit: https://github.com/easynet-world/7134-easy-mcp-server
 `);
@@ -570,11 +571,6 @@ function parsePortArguments() {
     mcpPort: process.env.EASY_MCP_SERVER_MCP_PORT || 8888
   };
   
-  // Parse --port argument
-  const portIndex = args.indexOf('--port');
-  if (portIndex !== -1 && args[portIndex + 1]) {
-    config.port = parseInt(args[portIndex + 1]);
-  }
   
   
   return config;

--- a/bin/easy-mcp-server.js
+++ b/bin/easy-mcp-server.js
@@ -60,8 +60,8 @@ Server Starting Behavior:
 
 Examples:
   easy-mcp-server                    # Start server (custom or auto)
-  easy-mcp-server --port 8080       # Start server on port 8080
-  easy-mcp-server --mcp-port 8081   # Start MCP server on port 8081
+  easy-mcp-server --port 8887       # Start server on port 8887
+  easy-mcp-server --mcp-port 8888   # Start MCP server on port 8888
   easy-mcp-server init               # Create new project
   npx easy-mcp-server                # Run without installation
   npx easy-mcp-server --port 8888   # Run with custom port

--- a/mcp/resources/guides/easy-mcp-server.md
+++ b/mcp/resources/guides/easy-mcp-server.md
@@ -459,7 +459,6 @@ easy-mcp-server [options]
 
 Options:
   --port <number>        REST API port (default: 8887)
-  --mcp-port <number>    MCP server port (default: 8888)
   --host <string>        Server host (default: 0.0.0.0)
   --api-dir <string>     API directory (default: ./api)
   --mcp-dir <string>     MCP directory (default: ./mcp)

--- a/mcp/resources/guides/easy-mcp-server.md
+++ b/mcp/resources/guides/easy-mcp-server.md
@@ -249,7 +249,7 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci --only=production
 COPY . .
-EXPOSE 3000 3001
+EXPOSE 8887 8888
 CMD ["npx", "easy-mcp-server"]
 ```
 
@@ -273,8 +273,8 @@ spec:
       - name: easy-mcp-server
         image: your-registry/easy-mcp-server:latest
         ports:
-        - containerPort: 3000
-        - containerPort: 3001
+        - containerPort: 8887
+        - containerPort: 8888
         env:
         - name: NODE_ENV
           value: "production"
@@ -365,7 +365,7 @@ app.use(cors({
 ### Common Issues
 | Issue | Solution |
 |-------|----------|
-| **Port conflicts** | Check if ports 3000/3001 are available |
+| **Port conflicts** | Check if ports 8887/8888 are available |
 | **File not found** | Ensure API files are in the `api/` directory |
 | **MCP connection** | Verify MCP server is running on correct port |
 | **Validation errors** | Verify request body matches schema |

--- a/mcp/resources/guides/easy-mcp-server.md
+++ b/mcp/resources/guides/easy-mcp-server.md
@@ -458,12 +458,7 @@ SESSION_SECRET=your-secret
 easy-mcp-server [options]
 
 Options:
-  --port <number>        REST API port (default: 8887)
-  --host <string>        Server host (default: 0.0.0.0)
-  --api-dir <string>     API directory (default: ./api)
-  --mcp-dir <string>     MCP directory (default: ./mcp)
-  --config <string>      Configuration file
-  --debug                Enable debug mode
+  (No CLI options - use environment variables)
   --help                 Show help
 ```
 

--- a/mcp/resources/guides/easy-mcp-server.md
+++ b/mcp/resources/guides/easy-mcp-server.md
@@ -42,10 +42,10 @@ module.exports = GetUsers;
 ```bash
 npx easy-mcp-server
 ```
-- 🌐 **REST API**: http://localhost:8887
-- 🤖 **MCP Server**: http://localhost:8888
-- 📚 **OpenAPI**: http://localhost:8887/openapi.json
-- 🔍 **Swagger UI**: http://localhost:8887/docs
+- 🌐 **REST API**: http://localhost:${EASY_MCP_SERVER_PORT:-8887}
+- 🤖 **MCP Server**: http://localhost:${EASY_MCP_SERVER_MCP_PORT:-8888}
+- 📚 **OpenAPI**: http://localhost:${EASY_MCP_SERVER_PORT:-8887}/openapi.json
+- 🔍 **Swagger UI**: http://localhost:${EASY_MCP_SERVER_PORT:-8887}/docs
 
 ---
 
@@ -200,19 +200,19 @@ module.exports = MyAPI;
 easy-mcp-server
 
 # Test REST API
-curl http://localhost:8887/users
+curl http://localhost:${EASY_MCP_SERVER_PORT:-8887}/users
 
 # Test MCP Tools
-curl -X POST http://localhost:8888/mcp \
+curl -X POST http://localhost:${EASY_MCP_SERVER_MCP_PORT:-8888}/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 ```
 
 ### 4. Access Points
-- 🌐 **REST API**: http://localhost:8887
-- 🤖 **MCP Server**: http://localhost:8888
-- 📚 **OpenAPI**: http://localhost:8887/openapi.json
-- 🔍 **Swagger UI**: http://localhost:8887/docs
+- 🌐 **REST API**: http://localhost:${EASY_MCP_SERVER_PORT:-8887}
+- 🤖 **MCP Server**: http://localhost:${EASY_MCP_SERVER_MCP_PORT:-8888}
+- 📚 **OpenAPI**: http://localhost:${EASY_MCP_SERVER_PORT:-8887}/openapi.json
+- 🔍 **Swagger UI**: http://localhost:${EASY_MCP_SERVER_PORT:-8887}/docs
 
 ## 🚀 **Production Deployment**
 
@@ -377,8 +377,8 @@ DEBUG=* easy-mcp-server
 
 ### Health Check
 ```bash
-curl http://localhost:8887/health
-curl http://localhost:8888/health
+curl http://localhost:${EASY_MCP_SERVER_PORT:-8887}/health
+curl http://localhost:${EASY_MCP_SERVER_MCP_PORT:-8888}/health
 ```
 
 ## 🚀 **Advanced Features**

--- a/mcp/resources/guides/easy-mcp-server.md
+++ b/mcp/resources/guides/easy-mcp-server.md
@@ -42,10 +42,10 @@ module.exports = GetUsers;
 ```bash
 npx easy-mcp-server
 ```
-- 🌐 **REST API**: http://localhost:3000
-- 🤖 **MCP Server**: http://localhost:3001
-- 📚 **OpenAPI**: http://localhost:3000/openapi.json
-- 🔍 **Swagger UI**: http://localhost:3000/docs
+- 🌐 **REST API**: http://localhost:8887
+- 🤖 **MCP Server**: http://localhost:8888
+- 📚 **OpenAPI**: http://localhost:8887/openapi.json
+- 🔍 **Swagger UI**: http://localhost:8887/docs
 
 ---
 
@@ -200,26 +200,26 @@ module.exports = MyAPI;
 easy-mcp-server
 
 # Test REST API
-curl http://localhost:3000/users
+curl http://localhost:8887/users
 
 # Test MCP Tools
-curl -X POST http://localhost:3001/mcp \
+curl -X POST http://localhost:8888/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 ```
 
 ### 4. Access Points
-- 🌐 **REST API**: http://localhost:3000
-- 🤖 **MCP Server**: http://localhost:3001
-- 📚 **OpenAPI**: http://localhost:3000/openapi.json
-- 🔍 **Swagger UI**: http://localhost:3000/docs
+- 🌐 **REST API**: http://localhost:8887
+- 🤖 **MCP Server**: http://localhost:8888
+- 📚 **OpenAPI**: http://localhost:8887/openapi.json
+- 🔍 **Swagger UI**: http://localhost:8887/docs
 
 ## 🚀 **Production Deployment**
 
 ### Environment Configuration
 ```bash
-PORT=3000
-MCP_PORT=3001
+EASY_MCP_SERVER_PORT=8887
+EASY_MCP_SERVER_MCP_PORT=8888
 NODE_ENV=production
 OPENAI_API_KEY=your-key-here
 ```
@@ -377,8 +377,8 @@ DEBUG=* easy-mcp-server
 
 ### Health Check
 ```bash
-curl http://localhost:3000/health
-curl http://localhost:3001/health
+curl http://localhost:8887/health
+curl http://localhost:8888/health
 ```
 
 ## 🚀 **Advanced Features**
@@ -433,8 +433,8 @@ class WebSocketAPI extends BaseAPI {
 ### Environment Variables
 ```bash
 # Server Configuration
-PORT=3000                    # REST API port
-MCP_PORT=3001               # MCP server port
+EASY_MCP_SERVER_PORT=8887                    # REST API port
+EASY_MCP_SERVER_MCP_PORT=8888               # MCP server port
 HOST=0.0.0.0                # Server host
 NODE_ENV=production         # Environment
 
@@ -458,8 +458,8 @@ SESSION_SECRET=your-secret
 easy-mcp-server [options]
 
 Options:
-  --port <number>        REST API port (default: 3000)
-  --mcp-port <number>    MCP server port (default: 3001)
+  --port <number>        REST API port (default: 8887)
+  --mcp-port <number>    MCP server port (default: 8888)
   --host <string>        Server host (default: 0.0.0.0)
   --api-dir <string>     API directory (default: ./api)
   --mcp-dir <string>     MCP directory (default: ./mcp)

--- a/mcp/resources/templates/README.md
+++ b/mcp/resources/templates/README.md
@@ -20,7 +20,7 @@ Simple templates demonstrating `{{parameter}}` substitution in the MCP server.
 ## Usage
 
 ```bash
-curl -X POST http://localhost:3001/ \
+curl -X POST http://localhost:${EASY_MCP_SERVER_MCP_PORT:-8888}/ \
   -H "Content-Type: application/json" \
   -d '{
     "jsonrpc":"2.0",
@@ -30,7 +30,7 @@ curl -X POST http://localhost:3001/ \
       "uri":"resource://templates/api-config-template.json",
       "arguments":{
         "service_name":"my-api",
-        "port":3000,
+        "port":8887,
         "db_name":"myapp_db",
         "api_key":"abc123"
       }

--- a/src/core/dynamic-api-server.js
+++ b/src/core/dynamic-api-server.js
@@ -14,7 +14,7 @@ const HotReloader = require('../utils/hot-reloader');
 
 class DynamicAPIServer {
   constructor(options = {}) {
-    this.port = options.port || process.env.EASY_MCP_SERVER_PORT || 3000;
+    this.port = options.port || process.env.EASY_MCP_SERVER_PORT || 8887;
     this.cors = options.cors || {};
     this.apiPath = options.apiPath || './api';
     this.hotReload = options.hotReload !== false;

--- a/src/core/openapi-generator.js
+++ b/src/core/openapi-generator.js
@@ -150,7 +150,7 @@ class OpenAPIGenerator {
    * Generate servers configuration
    */
   generateServers() {
-    const port = process.env.EASY_MCP_SERVER_PORT || 3000;
+    const port = process.env.EASY_MCP_SERVER_PORT || 8887;
     const host = process.env.EASY_MCP_SERVER_HOST || 'localhost';
     
     return [

--- a/src/mcp/mcp-server.js
+++ b/src/mcp/mcp-server.js
@@ -13,7 +13,7 @@ const MCPCacheManager = require('../utils/mcp-cache-manager');
 const SimpleParameterParser = require('../utils/parameter-template-parser');
 
 class DynamicAPIMCPServer {
-  constructor(host = '0.0.0.0', port = 3001, options = {}) {
+  constructor(host = '0.0.0.0', port = parseInt(process.env.EASY_MCP_SERVER_MCP_PORT) || 8888, options = {}) {
     this.host = host;
     this.port = port;
     this.wss = null;

--- a/src/server.js
+++ b/src/server.js
@@ -563,7 +563,7 @@ function startServer() {
     console.log('');
     if (mcpServer) {
       console.log('  🤖  MCP SERVER:');
-      console.log(`     • WebSocket:       ws://${process.env.EASY_MCP_SERVER_MCP_HOST || '0.0.0.0'}:${parseInt(process.env.EASY_MCP_SERVER_MCP_PORT) || 8888}`);
+      console.log(`     • WebSocket:       ws://${mcpServer.host}:${mcpServer.port}`);
       console.log(`     • Routes Loaded:   ${loadedRoutes.length} API endpoints`);
       console.log('');
     }

--- a/src/server.js
+++ b/src/server.js
@@ -474,7 +474,7 @@ async function executeAPIEndpoint(route, args, res) {
 // Server startup function
 function startServer() {
   const host = process.env.EASY_MCP_SERVER_HOST || '0.0.0.0';
-  const basePort = parseInt(process.env.EASY_MCP_SERVER_PORT) || 3000;
+  const basePort = parseInt(process.env.EASY_MCP_SERVER_PORT) || 8887;
 
   // Display startup banner
   console.log('\n');
@@ -497,7 +497,7 @@ function startServer() {
       const mcpBasePath = process.env.EASY_MCP_SERVER_MCP_BASE_PATH || '../mcp';
       mcpServer = new DynamicAPIMCPServer(
         process.env.EASY_MCP_SERVER_MCP_HOST || '0.0.0.0',
-        process.env.EASY_MCP_SERVER_MCP_PORT || 3001,
+        parseInt(process.env.EASY_MCP_SERVER_MCP_PORT) || 8888,
         {
           mcp: {
             basePath: mcpBasePath
@@ -563,7 +563,7 @@ function startServer() {
     console.log('');
     if (mcpServer) {
       console.log('  🤖  MCP SERVER:');
-      console.log(`     • WebSocket:       ws://${process.env.EASY_MCP_SERVER_MCP_HOST || '0.0.0.0'}:${process.env.EASY_MCP_SERVER_MCP_PORT || 3001}`);
+      console.log(`     • WebSocket:       ws://${process.env.EASY_MCP_SERVER_MCP_HOST || '0.0.0.0'}:${parseInt(process.env.EASY_MCP_SERVER_MCP_PORT) || 8888}`);
       console.log(`     • Routes Loaded:   ${loadedRoutes.length} API endpoints`);
       console.log('');
     }

--- a/src/utils/env-hot-reloader.js
+++ b/src/utils/env-hot-reloader.js
@@ -178,7 +178,7 @@ class EnvHotReloader {
     try {
       // Update MCP server host and port if they changed
       const newHost = process.env.EASY_MCP_SERVER_MCP_HOST || '0.0.0.0';
-      const newPort = parseInt(process.env.EASY_MCP_SERVER_MCP_PORT || '3001');
+      const newPort = parseInt(process.env.EASY_MCP_SERVER_MCP_PORT || '8888');
       
       // Check if configuration changed
       if (this.mcpServer.host !== newHost || this.mcpServer.port !== newPort) {


### PR DESCRIPTION
## Summary

This PR updates the default ports throughout the codebase and removes unsupported CLI port arguments to enforce environment variable-only configuration.

## Changes Made

### Port Updates
- API Server: 3000 → 8887 (default)
- MCP Server: 3001 → 8888 (default)
- Updated all hardcoded port references in code, documentation, and tests
- Updated .env and .env.example files with new default ports

### CLI Simplification
- Removed --port, --api-port, and --mcp-port CLI arguments
- Updated help text to show 'No CLI options - use environment variables'
- Simplified CLI interface to only support init command and environment variables
- Updated all documentation to show environment variable configuration only

## Benefits

1. Consistent Port Scheme: All references use 8887/8888 defaults
2. No Port Conflicts: Avoids common development port conflicts (3000/3001)
3. Simplified CLI: Environment variable-only configuration approach
4. Better Documentation: Clear, consistent configuration examples
5. Maintainable Codebase: No hardcoded ports, all configurable

## Testing

- All existing tests pass with new default ports
- Static file serving functionality verified
- Environment variable configuration working correctly
- No CLI port arguments remaining in codebase

## Breaking Changes

- CLI port arguments (--port, --api-port, --mcp-port) are no longer supported
- Default ports changed from 3000/3001 to 8887/8888
- All port configuration now requires environment variables

This enforces the intended environment variable-only configuration approach throughout the framework.