### PR TITLE
fix: Set environment variables before server import in static file serving tests

### DIFF
--- a/__tests__/static-file-serving.test.js
+++ b/__tests__/static-file-serving.test.js
@@ -2,6 +2,12 @@
  * Test cases for static file serving functionality
  */
 
+// Set environment variables before importing the server
+process.env.EASY_MCP_SERVER_STATIC_ENABLED = 'true';
+process.env.EASY_MCP_SERVER_STATIC_DIRECTORY = './public';
+process.env.EASY_MCP_SERVER_SERVE_INDEX = 'true';
+process.env.EASY_MCP_SERVER_DEFAULT_FILE = 'index.html';
+
 const request = require('supertest');
 const fs = require('fs');
 const path = require('path');
@@ -12,11 +18,6 @@ describe('Static File Serving', () => {
   const testHtmlContent = '<html><body><h1>Test</h1></body></html>';
   
   beforeAll(() => {
-    // Ensure static file serving is enabled for tests
-    process.env.EASY_MCP_SERVER_STATIC_ENABLED = 'true';
-    process.env.EASY_MCP_SERVER_STATIC_DIRECTORY = './public';
-    process.env.EASY_MCP_SERVER_SERVE_INDEX = 'true';
-    process.env.EASY_MCP_SERVER_DEFAULT_FILE = 'index.html';
     // Ensure public directory exists
     if (!fs.existsSync(publicDir)) {
       fs.mkdirSync(publicDir, { recursive: true });


### PR DESCRIPTION
## 🐛 Fix Static File Serving Tests in CI

This PR fixes the static file serving tests that were failing in the CI environment.

## 🔧 Root Cause

The issue was that environment variables were being set in the  hook, but the server was already initialized when the test file was imported. This meant that static file serving was not enabled when the server started.

## 🔧 Solution

- **Moved environment variable setup** to the top of the test file, before the server is imported
- **Set ** and related variables before server initialization
- **Removed duplicate setup** from the  hook

## 🧪 Test Results

- ✅ Static file serving tests now pass locally
- ✅ Environment variables are set before server initialization
- ✅ Static file serving is properly enabled in CI environment

## 📋 Files Changed

-  - Move env vars to top of file

## 🚀 Expected CI Results

This should resolve the static file serving test failures and allow the GitHub Action to complete successfully.