### PR TITLE
fix: Create test files before server initialization in static file serving test

### DIFF
--- a/__tests__/static-file-serving.test.js
+++ b/__tests__/static-file-serving.test.js
@@ -13,35 +13,34 @@ const request = require('supertest');
 const fs = require('fs');
 const path = require('path');
 
-// Import server after environment variables are set
+// Create public directory and test files before importing the server
+const publicDir = path.join(__dirname, '..', 'public');
+if (!fs.existsSync(publicDir)) {
+  fs.mkdirSync(publicDir, { recursive: true });
+}
+
+// Create test files before server initialization
+const testFiles = [
+  { name: 'index.html', content: '<html><body><h1>Hello World!</h1></body></html>' },
+  { name: 'test.html', content: '<html><body>test</body></html>' },
+  { name: 'style.css', content: 'body { color: blue; }' },
+  { name: 'app.js', content: 'console.log("test");' },
+  { name: 'test.json', content: '{"test": "data"}' },
+  { name: 'cache-test.html', content: '<html><body>Cache Test</body></html>' }
+];
+
+testFiles.forEach(file => {
+  const filePath = path.join(publicDir, file.name);
+  if (!fs.existsSync(filePath)) {
+    fs.writeFileSync(filePath, file.content);
+  }
+});
+
+// Import server after environment variables and files are set
 const { app } = require('../src/server');
 
 describe('Static File Serving - CI', () => {
   const publicDir = path.join(__dirname, '..', 'public');
-  
-  beforeAll(() => {
-    // Ensure public directory exists
-    if (!fs.existsSync(publicDir)) {
-      fs.mkdirSync(publicDir, { recursive: true });
-    }
-    
-    // Create some basic test files
-    const testFiles = [
-      { name: 'index.html', content: '<html><body><h1>Hello World!</h1></body></html>' },
-      { name: 'test.html', content: '<html><body>test</body></html>' },
-      { name: 'style.css', content: 'body { color: blue; }' },
-      { name: 'app.js', content: 'console.log("test");' },
-      { name: 'test.json', content: '{"test": "data"}' },
-      { name: 'cache-test.html', content: '<html><body>Cache Test</body></html>' }
-    ];
-    
-    testFiles.forEach(file => {
-      const filePath = path.join(publicDir, file.name);
-      if (!fs.existsSync(filePath)) {
-        fs.writeFileSync(filePath, file.content);
-      }
-    });
-  });
 
   afterAll(() => {
     // Clean up test files


### PR DESCRIPTION
## 🐛 Fix Static File Serving Test Files in CI

This PR fixes the static file serving test failures in CI by ensuring test files are created before the server is initialized.

## 🔧 Root Cause

The issue was that the static file serving tests were failing in CI because:

1. **Server Initialization Timing**: The server was being initialized when the test file was imported
2. **File Creation Timing**: Test files were being created in the  hook, which runs after the server is already initialized
3. **Static Directory Check**: The server checks for the existence of the static directory and files when it starts, but they didn't exist yet

## 🔧 Solution

- **Move file creation before server import**: Create test files before importing the server
- **Ensure static directory exists**: Create the  directory and test files before server initialization
- **Proper timing**: Files are now available when the server checks for static file serving configuration

## 🧪 Test Results

- ✅ Static file serving tests pass locally
- ✅ Files are created before server initialization
- ✅ Static file serving is properly configured with existing files
- ✅ All test cases cover HTML, CSS, JS, JSON files
- ✅ Root route handling works correctly
- ✅ Content type detection works properly
- ✅ Caching headers are set correctly

## 🎯 Expected Outcome

This should resolve the static file serving test failures in GitHub Actions and allow the release workflow to complete successfully.

## 📝 Changes Made

- Move test file creation from  hook to before server import
- Create  directory and test files before server initialization
- Remove duplicate file creation logic from  hook
- Ensure static file serving is properly configured with existing files

## 🔍 Technical Details

The key insight is that the server's static file serving configuration is determined when the server is initialized. If the static directory and files don't exist at that time, the static file serving middleware won't be set up, even if files are created later in the test.

By creating the files before importing the server, we ensure that:
1. The static directory exists when the server starts
2. The static file serving middleware is properly configured
3. The tests can successfully serve static files