### PR TITLE
fix: Update static file serving test to work with professional landing page

### DIFF
--- a/__tests__/static-file-serving.test.js
+++ b/__tests__/static-file-serving.test.js
@@ -15,7 +15,6 @@ if (!fs.existsSync(publicDir)) {
 
 // Create test files before server initialization
 const testFiles = [
-  { name: 'index.html', content: '<html><body><h1>Hello World!</h1></body></html>' },
   { name: 'test.html', content: '<html><body>test</body></html>' },
   { name: 'style.css', content: 'body { color: blue; }' },
   { name: 'app.js', content: 'console.log("test");' },
@@ -37,8 +36,8 @@ describe('Static File Serving - CI', () => {
   const publicDir = path.join(__dirname, '..', 'public');
 
   afterAll(() => {
-    // Clean up test files
-    const testFiles = ['index.html', 'test.html', 'style.css', 'app.js', 'test.json', 'cache-test.html'];
+    // Clean up test files (but keep the professional index.html)
+    const testFiles = ['test.html', 'style.css', 'app.js', 'test.json', 'cache-test.html'];
     testFiles.forEach(file => {
       const filePath = path.join(publicDir, file);
       if (fs.existsSync(filePath)) {
@@ -82,7 +81,7 @@ describe('Static File Serving - CI', () => {
         .get('/')
         .expect(200);
 
-      expect(response.text).toContain('<h1>Hello World!</h1>');
+      expect(response.text).toContain('🚀 Easy MCP Server');
       expect(response.headers['content-type']).toMatch(/text\/html/);
     });
   });


### PR DESCRIPTION
## 🐛 Fix Static File Serving Test for Professional Landing Page

This PR fixes the static file serving test to work correctly with the professional landing page that was added in the previous PR.

## 🔧 Root Cause

The static file serving tests were failing because:

1. **Content Mismatch**: Test was expecting simple content  but the actual  contains the professional landing page with 
2. **File Conflict**: Test was trying to create its own  file, conflicting with the professional landing page
3. **Cleanup Issue**: Test cleanup was trying to delete the professional landing page

## 🔧 Solution

- **Remove index.html from test creation**: Don't create a test  since the professional one exists
- **Update test expectations**: Change test to expect  instead of 
- **Update cleanup**: Preserve the professional  during test cleanup
- **Maintain test coverage**: All other static file serving tests remain intact

## 🧪 Test Results

- ✅ All static file serving tests pass locally
- ✅ Professional landing page is preserved
- ✅ Static file serving functionality works correctly
- ✅ Test cleanup doesn't interfere with committed files

## 📝 Changes Made

1. **Removed  from test file creation** - No longer creates conflicting file
2. **Updated test expectation** - Now expects  content
3. **Updated cleanup logic** - Preserves professional 
4. **Maintained test coverage** - All other static file tests unchanged

## 🎯 Expected Outcome

This should resolve the static file serving test failures in CI while preserving the professional landing page functionality.