### PR TITLE
fix(ci): resolve eslint errors introduced by debug logs

### DIFF
--- a/bin/easy-mcp-server.js
+++ b/bin/easy-mcp-server.js
@@ -445,16 +445,16 @@ describe('Easy MCP Server', () => {
    3. easy-mcp-server
 
 📚 Your server will be available at:
-   - Server: http://localhost:${config.port}
-   - API Docs: http://localhost:${config.port}/docs
-   - Health Check: http://localhost:${config.port}/health
-   - OpenAPI Spec: http://localhost:${config.port}/openapi.json
-   - API Info: http://localhost:${config.port}/api-info
+  - Server: http://localhost:${'${config.port}'}
+  - API Docs: http://localhost:${'${config.port}'}/docs
+  - Health Check: http://localhost:${'${config.port}'}/health
+  - OpenAPI Spec: http://localhost:${'${config.port}'}/openapi.json
+  - API Info: http://localhost:${'${config.port}'}/api-info
 
 🔌 MCP (Model Context Protocol) Integration:
-   - MCP Server: http://localhost:${config.mcpPort}
-   - MCP Tools: http://localhost:${config.port}/mcp/tools
-   - MCP Schema: http://localhost:${config.port}/mcp/schema
+  - MCP Server: http://localhost:${'${config.mcpPort}'}
+  - MCP Tools: http://localhost:${'${config.port}'}/mcp/tools
+  - MCP Schema: http://localhost:${'${config.port}'}/mcp/schema
    - Transport Types: Streamable HTTP, Server-Sent Events (SSE)
    - MCP Endpoints: GET /sse, POST /mcp, POST / (StreamableHttp)
 

--- a/src/server.js
+++ b/src/server.js
@@ -50,7 +50,7 @@ app.use(express.static(staticPath, {
   etag: true, // Enable ETags for caching
   lastModified: true // Enable Last-Modified headers
 }));
-console.log(`✅ Static file middleware applied successfully`);
+console.log('✅ Static file middleware applied successfully');
 
 // Handle root route with index.html if it exists
 if (staticConfig.serveIndex) {
@@ -572,24 +572,24 @@ function startServer() {
       console.log(`     • Routes Loaded:   ${loadedRoutes.length} API endpoints`);
       console.log('');
     }
-  console.log('  ⚡  FEATURES:');
-  console.log('     • Auto-discovery of API endpoints');
-  console.log('     • Real-time MCP tool generation');
-  console.log('     • Automatic OpenAPI documentation');
-  console.log('     • Hot reloading enabled');
-  if (staticConfig.enabled && fs.existsSync(path.resolve(staticConfig.directory))) {
-    console.log('     • Static file serving enabled');
-  }
-  console.log('');
-  console.log('  🎯  Ready to serve your APIs!');
-  console.log('  ' + '═'.repeat(78));
-  console.log('');
+    console.log('  ⚡  FEATURES:');
+    console.log('     • Auto-discovery of API endpoints');
+    console.log('     • Real-time MCP tool generation');
+    console.log('     • Automatic OpenAPI documentation');
+    console.log('     • Hot reloading enabled');
+    if (staticConfig.enabled && fs.existsSync(path.resolve(staticConfig.directory))) {
+      console.log('     • Static file serving enabled');
+    }
+    console.log('');
+    console.log('  🎯  Ready to serve your APIs!');
+    console.log('  ' + '═'.repeat(78));
+    console.log('');
   });
 
   server.on('error', (error) => {
     if (error.code === 'EADDRINUSE') {
       console.error(`❌ Port ${basePort} is already in use. Please choose a different port or stop the process using that port.`);
-      console.error(`   You can set a different port using: EASY_MCP_SERVER_PORT=<port>`);
+      console.error('   You can set a different port using: EASY_MCP_SERVER_PORT=<port>');
       process.exit(1);
     } else {
       console.error(`❌ Server error: ${error.message}`);


### PR DESCRIPTION
- Use single quotes and fix indentation in src/server.js
- Escape template expressions in bin/easy-mcp-server.js banner
- Lint passes locally; expect CI to pass tests and lint