### PR TITLE
chore(ci): fix lint in CLI static test

### DIFF
--- a/__tests__/static-file-serving-cli.test.js
+++ b/__tests__/static-file-serving-cli.test.js
@@ -27,7 +27,7 @@ describe('CLI Static File Serving', () => {
     fs.mkdirSync(apiDir, { recursive: true });
     fs.writeFileSync(
       path.join(apiDir, 'get.js'),
-      "const BaseAPI = require('easy-mcp-server/base-api');\nclass TestAPI extends BaseAPI { process(req, res){ res.json({ ok: true }); } }\nmodule.exports = TestAPI;\n"
+      'const BaseAPI = require(\'easy-mcp-server/base-api\');\nclass TestAPI extends BaseAPI { process(req, res){ res.json({ ok: true }); } }\nmodule.exports = TestAPI;\n'
     );
 
     const publicDir = path.join(tempDir, 'public');


### PR DESCRIPTION
Fix ESLint quotes rule in CLI static test to unblock release.