### PR TITLE
test(ci): fully close child processes to avoid open handle warnings

### DIFF
--- a/__tests__/auto-install.test.js
+++ b/__tests__/auto-install.test.js
@@ -79,14 +79,18 @@ module.exports = TestAPI;
       
       expect(hasInstallMessage || hasServerMessage).toBe(true);
       
-      // Clean up
+      // Clean up and ensure child process fully exits
+      let finished = false;
+      const finish = () => { if (!finished) { finished = true; done(); } };
+      serverProcess.once('close', finish);
       serverProcess.kill('SIGTERM');
       setTimeout(() => {
         if (!serverProcess.killed) {
           serverProcess.kill('SIGKILL');
         }
-        done();
-      }, 100);
+        // Fallback in case 'close' wasn't emitted
+        finish();
+      }, 300);
     }, 5000); // Longer timeout for npm install
   });
 
@@ -134,14 +138,17 @@ module.exports = TestAPI;
       
       expect(hasSkipMessage || hasServerMessage).toBe(true);
       
-      // Clean up
+      // Clean up and ensure child process fully exits
+      let finished = false;
+      const finish = () => { if (!finished) { finished = true; done(); } };
+      serverProcess.once('close', finish);
       serverProcess.kill('SIGTERM');
       setTimeout(() => {
         if (!serverProcess.killed) {
           serverProcess.kill('SIGKILL');
         }
-        done();
-      }, 100);
+        finish();
+      }, 300);
     }, 3000);
   });
 
@@ -199,14 +206,17 @@ module.exports = TestAPI;
       
       expect(hasInstallMessage || hasServerMessage).toBe(true);
       
-      // Clean up
+      // Clean up and ensure child process fully exits
+      let finished = false;
+      const finish = () => { if (!finished) { finished = true; done(); } };
+      serverProcess.once('close', finish);
       serverProcess.kill('SIGTERM');
       setTimeout(() => {
         if (!serverProcess.killed) {
           serverProcess.kill('SIGKILL');
         }
-        done();
-      }, 100);
+        finish();
+      }, 300);
     }, 8000); // Longer timeout for failed npm install
   });
 });

--- a/__tests__/env-loading.test.js
+++ b/__tests__/env-loading.test.js
@@ -73,13 +73,16 @@ module.exports = TestAPI;
       expect(output).toContain('📄 Loaded environment from .env');
       
       // Clean up
+      let finished = false;
+      const finish = () => { if (!finished) { finished = true; done(); } };
+      serverProcess.once('close', finish);
       serverProcess.kill('SIGTERM');
       setTimeout(() => {
         if (!serverProcess.killed) {
           serverProcess.kill('SIGKILL');
         }
-        done();
-      }, 100);
+        finish();
+      }, 300);
     }, 3000);
   });
 
@@ -130,13 +133,16 @@ module.exports = TestAPI;
       expect(output).toContain('📄 Loaded environment from .env');
       
       // Clean up
+      let finished2 = false;
+      const finish2 = () => { if (!finished2) { finished2 = true; done(); } };
+      serverProcess.once('close', finish2);
       serverProcess.kill('SIGTERM');
       setTimeout(() => {
         if (!serverProcess.killed) {
           serverProcess.kill('SIGKILL');
         }
-        done();
-      }, 100);
+        finish2();
+      }, 300);
     }, 3000);
   });
 
@@ -180,13 +186,16 @@ module.exports = TestAPI;
       expect(output).not.toContain('📄 Loaded environment from');
       
       // Clean up
+      let finished3 = false;
+      const finish3 = () => { if (!finished3) { finished3 = true; done(); } };
+      serverProcess.once('close', finish3);
       serverProcess.kill('SIGTERM');
       setTimeout(() => {
         if (!serverProcess.killed) {
           serverProcess.kill('SIGKILL');
         }
-        done();
-      }, 100);
+        finish3();
+      }, 300);
     }, 3000);
   });
 });

--- a/__tests__/mcp-sse-notifications.test.js
+++ b/__tests__/mcp-sse-notifications.test.js
@@ -75,7 +75,7 @@ describe('MCP SSE Notifications', () => {
             const line = event.split('\n').find(l => l.startsWith('data: '));
             if (line) {
               try {
-                const payload = JSON.parse(line.slice(6));
+                JSON.parse(line.slice(6));
                 resolve({ res, req, onEvent: (handler) => {
                   res.removeAllListeners('data');
                   res.on('data', (ch) => {
@@ -83,7 +83,7 @@ describe('MCP SSE Notifications', () => {
                     for (const part of parts) {
                       const l = part.split('\n').find(s => s.startsWith('data: '));
                       if (l) {
-                        try { handler(JSON.parse(l.slice(6))); } catch(_) {}
+                        try { handler(JSON.parse(l.slice(6))); } catch(parseEventError) { void 0; }
                       }
                     }
                   });
@@ -91,7 +91,7 @@ describe('MCP SSE Notifications', () => {
                   try { res.destroy(); } catch(errCloseRes) { /* ignore close error */ }
                   try { req.destroy(); } catch(errCloseReq) { /* ignore close error */ }
                 }});
-              } catch (parseInitError) { /* ignore non-JSON init chunk */ }
+              } catch (parseInitError) { void 0; }
             }
           }
         });

--- a/__tests__/mcp-sse-notifications.test.js
+++ b/__tests__/mcp-sse-notifications.test.js
@@ -88,10 +88,10 @@ describe('MCP SSE Notifications', () => {
                     }
                   });
                 }, close: () => {
-                  try { res.destroy(); } catch(_) {}
-                  try { req.destroy(); } catch(_) {}
+                  try { res.destroy(); } catch(errCloseRes) { /* ignore close error */ }
+                  try { req.destroy(); } catch(errCloseReq) { /* ignore close error */ }
                 }});
-              } catch (_) {}
+              } catch (parseInitError) { /* ignore non-JSON init chunk */ }
             }
           }
         });

--- a/__tests__/mcp-sse-notifications.test.js
+++ b/__tests__/mcp-sse-notifications.test.js
@@ -47,7 +47,7 @@ describe('MCP SSE Notifications', () => {
     }
     try {
       await fs.rm(tempDir, { recursive: true, force: true });
-    } catch (_) {}
+    } catch (cleanupError) { /* ignore cleanup error */ }
   });
 
   function connectSSE() {

--- a/__tests__/port-configuration.test.js
+++ b/__tests__/port-configuration.test.js
@@ -61,13 +61,16 @@ module.exports = TestAPI;
       expect(output).toContain('🚀 Starting Easy MCP Server...');
       
       // Clean up
+      let finished = false;
+      const finish = () => { if (!finished) { finished = true; done(); } };
+      serverProcess.once('close', finish);
       serverProcess.kill('SIGTERM');
       setTimeout(() => {
         if (!serverProcess.killed) {
           serverProcess.kill('SIGKILL');
         }
-        done();
-      }, 100);
+        finish();
+      }, 300);
     }, 3000);
   });
 
@@ -111,13 +114,16 @@ module.exports = TestAPI;
       expect(output).toContain('🚀 Starting Easy MCP Server...');
       
       // Clean up
+      let finished2 = false;
+      const finish2 = () => { if (!finished2) { finished2 = true; done(); } };
+      serverProcess.once('close', finish2);
       serverProcess.kill('SIGTERM');
       setTimeout(() => {
         if (!serverProcess.killed) {
           serverProcess.kill('SIGKILL');
         }
-        done();
-      }, 100);
+        finish2();
+      }, 300);
     }, 3000);
   });
 
@@ -174,13 +180,16 @@ EASY_MCP_SERVER_MCP_PORT=8888
       expect(output).toContain('🚀 Starting Easy MCP Server...');
       
       // Clean up
+      let finished3 = false;
+      const finish3 = () => { if (!finished3) { finished3 = true; done(); } };
+      serverProcess.once('close', finish3);
       serverProcess.kill('SIGTERM');
       setTimeout(() => {
         if (!serverProcess.killed) {
           serverProcess.kill('SIGKILL');
         }
-        done();
-      }, 100);
+        finish3();
+      }, 300);
     }, 3000);
   });
 
@@ -237,13 +246,16 @@ MCP_PORT=8888
       expect(output).toContain('🚀 Starting Easy MCP Server...');
       
       // Clean up
+      let finished4 = false;
+      const finish4 = () => { if (!finished4) { finished4 = true; done(); } };
+      serverProcess.once('close', finish4);
       serverProcess.kill('SIGTERM');
       setTimeout(() => {
         if (!serverProcess.killed) {
           serverProcess.kill('SIGKILL');
         }
-        done();
-      }, 100);
+        finish4();
+      }, 300);
     }, 3000);
   });
 
@@ -292,13 +304,16 @@ module.exports = TestAPI;
       expect(output).toContain('🚀 Starting Easy MCP Server...');
       
       // Clean up
+      let finished5 = false;
+      const finish5 = () => { if (!finished5) { finished5 = true; done(); } };
+      serverProcess.once('close', finish5);
       serverProcess.kill('SIGTERM');
       setTimeout(() => {
         if (!serverProcess.killed) {
           serverProcess.kill('SIGKILL');
         }
-        done();
-      }, 100);
+        finish5();
+      }, 300);
     }, 3000);
   });
 });

--- a/public/index.html
+++ b/public/index.html
@@ -470,7 +470,7 @@
         }
       } catch (_) {}
     };
-  } catch (_) {
+  } catch (sseInitError) {
     setStatus('Unavailable', false);
   }
 })();

--- a/src/mcp/mcp-server.js
+++ b/src/mcp/mcp-server.js
@@ -676,7 +676,7 @@ class DynamicAPIMCPServer {
     this.server.on('error', (err) => {
       try {
         console.error('❌ MCP HTTP server error (continuing):', err);
-      } catch (_) {}
+      } catch (logErr) { /* ignore logging error */ }
     });
     
     // Add HTTP endpoints for MCP Inspector compatibility
@@ -686,11 +686,11 @@ class DynamicAPIMCPServer {
       } catch (err) {
         try {
           console.error('❌ MCP HTTP request handling error:', err);
-        } catch (_) {}
+        } catch (logErr) { /* ignore logging error */ }
         try {
           res.writeHead(500, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Internal Server Error' }));
-        } catch (_) {}
+        } catch (writeErr) { /* ignore write error */ }
       }
     });
     
@@ -848,7 +848,12 @@ class DynamicAPIMCPServer {
     });
 
     req.on('error', (error) => {
-      console.error('❌ SSE connection error:', error);
+      // ECONNRESET/aborted is normal when clients disconnect
+      if (error && (error.code === 'ECONNRESET' || error.message === 'aborted')) {
+        console.log('🔌 MCP SSE client connection closed');
+      } else {
+        console.warn('⚠️  SSE connection issue:', error?.message || error);
+      }
       this.httpClients.delete(clientId);
     });
   }


### PR DESCRIPTION
Ensure spawned servers are SIGTERM/SIGKILLed and await 'close' with fallback, removing PIPEWRAP open handle notices in Jest.