### PR TITLE
fix(test): update hot-reloader test to handle absolute paths

### DIFF
--- a/__tests__/hot-reloader.test.js
+++ b/__tests__/hot-reloader.test.js
@@ -64,8 +64,9 @@ describe('HotReloader', () => {
       
       hotReloader.startWatching();
       
+      // Accept absolute or relative paths that end with the api glob pattern
       expect(mockChokidar.watch).toHaveBeenCalledWith(
-        'api/**/*.js',
+        expect.stringMatching(/.*api\/\*\*\/\*\.js$/),
         expect.objectContaining({
           ignored: expect.any(Array),
           persistent: true


### PR DESCRIPTION
## Problem
The hot-reloader test was failing in CI because it expected relative paths but the implementation uses absolute paths.

## Solution
- Changed  to 
- This regex pattern matches any path that ends with , handling both absolute and relative paths
- Test now properly handles CI environment where absolute paths are used

## Testing
- ✅ Test passes locally
- ✅ Fixes CI failure in hot-reloader test

## Changes
- Updated  to use regex pattern matching instead of string containing