### PR TITLE
feat: implement client notifications for MCP components refresh after…

### DIFF
--- a/src/mcp/mcp-server.js
+++ b/src/mcp/mcp-server.js
@@ -110,6 +110,10 @@ class DynamicAPIMCPServer {
     
     // Notify all connected clients about route changes
     this.notifyRouteChanges(routes);
+    
+    // Also notify about prompts and resources changes after hot reload
+    this.notifyPromptsChanged();
+    this.notifyResourcesChanged();
   }
 
   /**


### PR DESCRIPTION
… hot reload

- Add notifyMCPComponentsRefresh() method to HotReloader
- Clear MCP cache during hot reload for fresh data
- Notify clients about tools, prompts, and resources changes
- Send comprehensive refresh notification to all connected clients
- Enhance setRoutes() to notify about prompts and resources changes
- Support both WebSocket and HTTP/SSE client notifications

This ensures that after hot reload, all connected clients are automatically notified to refresh all MCP components (tools, prompts, resources) without manual intervention, providing a seamless development experience.