### PR TITLE
fix: update test to expect server name prefixed bridge tools

### DIFF
--- a/__tests__/mcp.tools.merge-bridge.test.js
+++ b/__tests__/mcp.tools.merge-bridge.test.js
@@ -40,7 +40,7 @@ describe('MCP tools/list merges bridge tools (HTTP MCP)', () => {
     const resp = await mcpServer.processMCPRequest({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
     expect(resp && resp.result && Array.isArray(resp.result.tools)).toBe(true);
     const names = resp.result.tools.map(t => t.name);
-    expect(names).toContain('mock_bridge_tool');
+    expect(names).toContain('mock_mock_bridge_tool');
   });
 });
 


### PR DESCRIPTION
## 🔧 Test Fix for Server Name Prefixing

This PR fixes the failing test that was expecting the old bridge tool naming format.

### 🐛 **Issue Fixed:**
- Test was expecting  but server name prefixing now returns 
- GitHub Actions were failing due to this test mismatch

### ✅ **Changes Made:**
- **Updated Test Expectation**: Changed test to expect  (server name + tool name)
- **Validates New Feature**: Test now correctly validates the server name prefixing functionality
- **Maintains Test Coverage**: All existing functionality is still properly tested

### 🧪 **Testing:**
- ✅ All tests now pass locally
- ✅ Server name prefixing feature works correctly
- ✅ Bridge tools are properly prefixed with server names

### 📋 **Technical Details:**
- **File Modified**: 
- **Change**: Updated expected tool name from  to 
- **Reason**: Reflects the new server name prefixing feature where bridge tools are prefixed with server name

This fix ensures the GitHub Actions will pass and validates that the server name prefixing feature is working correctly.