### PR TITLE
fix: update test expectation to match new MCP tool naming format

### DIFF
--- a/__tests__/mcp.tools.merge-bridge.test.js
+++ b/__tests__/mcp.tools.merge-bridge.test.js
@@ -40,7 +40,7 @@ describe('MCP tools/list merges bridge tools (HTTP MCP)', () => {
     const resp = await mcpServer.processMCPRequest({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
     expect(resp && resp.result && Array.isArray(resp.result.tools)).toBe(true);
     const names = resp.result.tools.map(t => t.name);
-    expect(names).toContain('mock_mock_bridge_tool');
+    expect(names).toContain('/mock/mock_bridge_tool');
   });
 });
 


### PR DESCRIPTION
## Summary

This PR fixes the GitHub Action test failure by updating the test expectation in `mcp.tools.merge-bridge.test.js` to match the new MCP tool naming format.

## Changes

- Updated test expectation from `'mock_mock_bridge_tool'` to `'/mock/mock_bridge_tool'`
- This aligns with the recent MCP tool naming update that uses forward slash format
- Resolves the failing test that was causing GitHub Actions to fail

## Testing

- ✅ All tests now pass (407 total, 4 skipped)
- ✅ Linting passes without issues
- ✅ No regressions in existing functionality

## Related

- Fixes the GitHub Action failure in run #18300734611
- Related to the MCP tool naming update from PR #246