### PR TITLE
fix: make static file serving test robust to quote style changes

### DIFF
--- a/__tests__/static-file-serving.test.js
+++ b/__tests__/static-file-serving.test.js
@@ -96,8 +96,8 @@ describe('Static File Serving - CI', () => {
         .get('/app.js')
         .expect(200);
 
-      console.log('Actual content:', JSON.stringify(response.text));
-      expect(response.text).toContain('console.log("test");');
+      // Check for either single or double quotes to handle ESLint auto-fixing
+      expect(response.text).toMatch(/console\.log\(['"]test['"]\);?/);
       expect(response.headers['content-type']).toMatch(/application\/javascript/);
     });
   });


### PR DESCRIPTION
## Summary

This PR makes the static file serving test more robust to handle quote style changes that may occur during ESLint auto-fixing in GitHub Actions.

## Problem

The GitHub Action was failing because:
- **Test expectation**:  (double quotes)
- **Actual content**:  (single quotes)
- **Root cause**: ESLint auto-fixing changes double quotes to single quotes during the CI run

## Solution

Updated the test to use a regex pattern that matches both single and double quotes:


## Benefits

- ✅ **Robust**: Works with both single and double quotes
- ✅ **ESLint-safe**: Handles auto-fixing during CI runs
- ✅ **Maintainable**: No need to update test when quote style changes
- ✅ **Backward compatible**: Still validates the correct content

## Testing

- ✅ Test passes locally with double quotes
- ✅ Test would pass with single quotes (simulated)
- ✅ No regressions in other tests
- ✅ Maintains test coverage for static file serving