### PR TITLE
fix: Update Node.js version to 20 in GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies


### PR DESCRIPTION
## 🔧 Fix GitHub Actions Node.js Version

### 🐛 Issue
GitHub Actions was failing because semantic-release requires Node.js >=20.8.1, but the workflow was using Node.js 18.

### ✅ Solution
- Updated Node.js version from 18 to 20 in 
- This ensures compatibility with semantic-release tool
- Fixes the release workflow failures

### 📊 Impact
- GitHub Actions release workflow will now pass
- semantic-release will work correctly with Node.js 20
- No impact on existing functionality