### PR TITLE
fix: Update semantic-release configuration

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -40,8 +40,14 @@
     ["@semantic-release/npm", {
       "npmPublish": true,
       "registry": "https://registry.npmjs.org/",
-      "access": "public"
+      "access": "public",
+      "tarballDir": "dist"
     }],
-    "@semantic-release/github"
+    ["@semantic-release/github", {
+      "failComment": false,
+      "failTitle": false,
+      "successComment": false,
+      "releasedLabels": false
+    }]
   ]
 }


### PR DESCRIPTION
## 🔧 Fix Semantic-Release Configuration

### 🐛 Issues Identified
1. **GitHub API Error**: Invalid label 'semantic-release' causing 422 validation error
2. **NPM Token**: 401 Unauthorized error (though token is set)

### ✅ Solutions Applied
- **Disabled GitHub issue creation** on failure to avoid label validation errors
- **Added tarballDir** to npm configuration for better package handling
- **Disabled automatic GitHub comments** to reduce API calls

### 📊 Expected Results
- Should resolve GitHub API validation errors
- May help with NPM token authentication
- Cleaner release process without automatic issue creation

### 🔍 Next Steps
If NPM token issue persists, may need to:
- Verify token has correct permissions (publish access)
- Check if token is classic vs automation token
- Ensure token is not expired