### PR TITLE
fix: Temporarily disable npm publishing to test release process

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -38,7 +38,7 @@
       "changelogFile": "CHANGELOG.md"
     }],
     ["@semantic-release/npm", {
-      "npmPublish": true,
+      "npmPublish": false,
       "registry": "https://registry.npmjs.org/",
       "access": "public",
       "tarballDir": "dist"


### PR DESCRIPTION
## 🔧 Temporarily Disable NPM Publishing

### 🐛 Current Issue
- **NPM Token Authentication**: 401 Unauthorized error persists despite NPM_TOKEN being set
- **Release Process**: Cannot complete due to npm authentication failure

### ✅ Solution Applied
- **Temporarily disabled npm publishing** ()
- This allows us to test if the rest of the release process works
- GitHub releases and changelog generation should still work

### 🔍 Next Steps
Once this PR is merged and we confirm the release process works:
1. **Investigate NPM token issue**:
   - Check if token is classic vs automation token
   - Verify token has publish permissions
   - Check if token is expired
   - Ensure token format is correct

2. **Re-enable npm publishing** once token issue is resolved

### 📊 Expected Results
- GitHub Actions should pass (without npm publishing)
- GitHub release should be created
- Changelog should be updated
- We can then focus on fixing the NPM token issue separately