### PR TITLE
test: Temporarily disable npm publishing to isolate the issue

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -38,7 +38,7 @@
       "changelogFile": "CHANGELOG.md"
     }],
     ["@semantic-release/npm", {
-      "npmPublish": true,
+      "npmPublish": false,
       "registry": "https://registry.npmjs.org/",
       "access": "public"
     }],


### PR DESCRIPTION
## 🧪 Test to Isolate the Issue

### 🐛 Current Problem
- **NPM Token**: 401 Unauthorized error persists even with original configuration
- **GitHub Label**: Still getting label validation error
- **Need to isolate**: Is the issue with npm publishing or other parts?

### ✅ Test Applied
- **Temporarily disabled npm publishing** ()
- **This bypasses NPM token authentication** completely
- **Tests if the rest of the release process works**

### 🎯 Expected Results
- **GitHub Actions should pass** (without npm publishing)
- **GitHub release should be created**
- **Changelog should be updated**
- **We can then focus on fixing the NPM token issue separately**

### 🔍 Next Steps
If this test passes:
1. **NPM token issue is confirmed** as the root cause
2. **Focus on fixing the NPM token** in repository settings
3. **Re-enable npm publishing** once token is fixed

If this test still fails:
1. **Issue is not with npm publishing**
2. **Need to investigate other causes**