### PR TITLE
fix: Re-enable npm publishing to test with valid NPM_TOKEN

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -38,7 +38,7 @@
       "changelogFile": "CHANGELOG.md"
     }],
     ["@semantic-release/npm", {
-      "npmPublish": false,
+      "npmPublish": true,
       "registry": "https://registry.npmjs.org/",
       "access": "public"
     }],


### PR DESCRIPTION
## 🔧 Re-enable NPM Publishing

### 🐛 Current Status
- **NPM_TOKEN is defined and not expired** (as confirmed by user)
- **Need to test if npm publishing works** with the valid token
- **Previous failures might be due to other issues**

### ✅ Solution Applied
- **Re-enabled npm publishing** ()
- **Testing with the NPM_TOKEN** that is defined and not expired
- **This should work if the token has correct permissions and format**

### 🎯 Expected Results
- **NPM publishing should work** if token is valid and has correct permissions
- **GitHub Actions should pass** with both npm publishing and GitHub releases
- **Package should be published to npm**

### 🔍 Possible Issues to Check
If it still fails, the issue might be:
1. **Token type**: Must be a classic token (not automation token)
2. **Token permissions**: Must have publish scope
3. **Token format**: Must start with  and be the full token
4. **2FA settings**: If 2FA is enabled, must be set to 'Authorization only'