### PR TITLE
fix: Disable GitHub issue creation to resolve label validation error

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -42,6 +42,11 @@
       "registry": "https://registry.npmjs.org/",
       "access": "public"
     }],
-    "@semantic-release/github"
+    ["@semantic-release/github", {
+      "failComment": false,
+      "failTitle": false,
+      "successComment": false,
+      "releasedLabels": false
+    }]
   ]
 }


### PR DESCRIPTION
## 🔧 Fix GitHub Label Validation Error

### 🐛 Issues Identified
1. **GitHub Label Error**: 
2. **NPM Token Issue**: Still getting 401 Unauthorized error

### ✅ Solution Applied
- **Disabled GitHub issue creation** on failure to prevent label validation error
- **This eliminates the GitHub API error** that was causing the release to fail
- **Focus on resolving the NPM token issue separately**

### 🎯 Expected Results
- **GitHub Actions should pass** (without the label validation error)
- **NPM publishing may still fail** due to token issue, but GitHub release should work
- **Cleaner error handling** without automatic issue creation

### 🔍 Next Steps for NPM Token
The NPM token issue needs to be resolved in repository settings:
1. **Token type**: Must be a classic token (not automation token)
2. **Token permissions**: Must have publish scope
3. **Token format**: Must start with  and be the full token
4. **2FA settings**: If 2FA is enabled, must be set to 'Authorization only'