### PR TITLE
fix: Restore original working semantic-release configuration

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -42,11 +42,6 @@
       "registry": "https://registry.npmjs.org/",
       "access": "public"
     }],
-    ["@semantic-release/github", {
-      "failComment": false,
-      "failTitle": false,
-      "successComment": false,
-      "releasedLabels": false
-    }]
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## 🔧 Restore Original Working Configuration

### 🐛 Root Cause Identified
- **NPM_TOKEN was working before** - the issue was configuration changes
- **Extra GitHub options** were interfering with npm publishing
- **Original working configuration** was much simpler

### ✅ Solution Applied
- **Reverted to exact original working configuration**
- **Removed extra GitHub options** that were causing conflicts
- **Back to simple `@semantic-release/github`** configuration

### 🎯 Expected Results
- **NPM publishing should work again** with the existing NPM_TOKEN
- **GitHub Actions should pass** with both npm publishing and GitHub releases
- **Back to the exact configuration** that was working before our changes

### 🔍 What Was Wrong
The extra GitHub configuration options I added were interfering with the npm publishing process. The original simple configuration was working perfectly with the existing NPM_TOKEN.