### PR TITLE
fix: Remove unnecessary GITHUB_TOKEN references

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -33,6 +32,5 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## 🔧 Fix GITHUB_TOKEN References

### 🎯 Purpose
- **Remove explicit GITHUB_TOKEN references** that are not needed
- **Use automatic GITHUB_TOKEN** provided by GitHub Actions
- **Resolve potential token conflicts** in the release process

### ✅ Changes Made
- **Removed explicit GITHUB_TOKEN from checkout step** (automatically provided)
- **Removed explicit GITHUB_TOKEN from Release step environment**
- **GITHUB_TOKEN is automatically available** in GitHub Actions

### 🎯 Expected Results
- **Cleaner workflow configuration** without unnecessary token references
- **No token conflicts** in the release process
- **Successful package publishing** to npm registry

### 🔍 What We're Testing
- Automatic GITHUB_TOKEN usage
- NPM publishing with updated NPM_TOKEN
- Complete release process without token conflicts