### PR TITLE
fix: Add back GITHUB_TOKEN to Release step environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,5 +32,6 @@ jobs:
 
       - name: Release
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## 🔧 Fix Both Token Issues

### 🎯 Purpose
- **Add back GITHUB_TOKEN** to Release step environment (semantic-release needs it)
- **Keep NPM_TOKEN** for npm publishing
- **Resolve both ENOGHTOKEN and EINVALIDNPMTOKEN errors**

### ✅ Changes Made
- **Added GITHUB_TOKEN back** to Release step environment variables
- **Kept NPM_TOKEN** for npm registry authentication
- **semantic-release needs explicit GITHUB_TOKEN** in environment

### 🎯 Expected Results
- **GitHub authentication should work** with explicit GITHUB_TOKEN
- **NPM authentication should work** with updated NPM_TOKEN
- **Complete release process** should succeed

### 🔍 What We're Testing
- Both GitHub and NPM token authentication
- Complete semantic-release process
- Package publishing to npm registry