### PR TITLE
test: Remove explicit GITHUB_TOKEN to test automatic token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,5 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## 🧪 Test Automatic GITHUB_TOKEN

### 🎯 Purpose
- **Test if we really need explicit GITHUB_TOKEN** in environment
- **GitHub Actions automatically provides GITHUB_TOKEN**
- **Test if semantic-release can find the automatic token**
- **Only keep NPM_TOKEN for npm publishing**

### ✅ Changes Made
- **Removed explicit GITHUB_TOKEN** from Release step environment
- **Kept only NPM_TOKEN** for npm registry authentication
- **GitHub Actions should automatically provide GITHUB_TOKEN**

### 🎯 Expected Results
- **If successful**: We don't need explicit GITHUB_TOKEN
- **If failed**: We need to add it back
- **Test the minimal configuration** for semantic-release

### 🔍 What We're Testing
- Automatic GITHUB_TOKEN detection by semantic-release
- NPM publishing with NPM_TOKEN
- Minimal environment variable configuration