### PR TITLE
fix: Use NODE_AUTH_TOKEN instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,5 +32,6 @@ jobs:
 
       - name: Release
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## 🔧 Fix NPM Authentication Pattern

### 🎯 Purpose
- **Use NODE_AUTH_TOKEN instead of NPM_TOKEN** (based on working repository pattern)
- **Follow the standard npm authentication approach** used in other repositories
- **Resolve the EINVALIDNPMTOKEN error** with proper token mapping

### ✅ Changes Made
- **Changed NPM_TOKEN to NODE_AUTH_TOKEN** in Release step environment
- **Kept GITHUB_TOKEN** for GitHub authentication
- **Based on working pattern** from 7129-easy-postgresql-accessor repository

### 🎯 Expected Results
- **NPM authentication should work** with NODE_AUTH_TOKEN
- **GitHub authentication should work** with GITHUB_TOKEN
- **Complete release process** should succeed

### 🔍 What We're Testing
- Standard npm authentication pattern
- Both GitHub and NPM token authentication
- Complete semantic-release process