### PR TITLE
fix: Add missing conventional-changelog-conventionalcommits dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/github": "^9.2.6",
     "@semantic-release/npm": "^11.0.2",
+    "conventional-changelog-conventionalcommits": "^7.0.0",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
     "nodemon": "^3.1.10",


### PR DESCRIPTION
## 🔧 Fix Missing Dependency

### 🎯 Purpose
- **Add missing conventional-changelog-conventionalcommits dependency**
- **Resolve MODULE_NOT_FOUND error in semantic-release**
- **Complete the release process successfully**

### ✅ Changes Made
- **Added conventional-changelog-conventionalcommits to devDependencies**
- **NPM and GitHub authentication are working correctly**
- **This should resolve the final blocking issue**

### 🎯 Expected Results
- **Release process should complete successfully**
- **Package should be published to npm**
- **GitHub release should be created**

### 🔍 What We're Testing
- Complete semantic-release process
- NPM publishing with working NPM_TOKEN
- GitHub release creation with working GITHUB_TOKEN