### PR TITLE
fix: Update package-lock.json to sync with new dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/github": "^9.2.6",
         "@semantic-release/npm": "^11.0.2",
+        "conventional-changelog-conventionalcommits": "^7.0.0",
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
         "nodemon": "^3.1.10",
@@ -3001,6 +3002,19 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
       "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
## 🔧 Fix Package Lock Sync Issue

### 🎯 Purpose
- **Update package-lock.json to sync with conventional-changelog-conventionalcommits dependency**
- **Resolve npm ci sync error in GitHub Actions**
- **Complete the release process successfully**

### ✅ Changes Made
- **Updated package-lock.json to include the new dependency**
- **package.json and package-lock.json are now in sync**
- **This resolves the 'Missing: conventional-changelog-conventionalcommits@7.0.2 from lock file' error**

### 🎯 Expected Results
- **npm ci should work in GitHub Actions**
- **Release process should complete successfully**
- **Package should be published to npm**

### 🔍 What We're Testing
- Complete semantic-release process with synced dependencies
- NPM publishing with working NPM_TOKEN
- GitHub release creation with working GITHUB_TOKEN