### PR TITLE
docs: Add clickable link to example-project in Documentation Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ EASY_MCP_SERVER_QUIET=false
 | Document | Purpose | Best For |
 |----------|---------|----------|
 | **[Development Guide](DEVELOPMENT.md)** | Comprehensive development documentation with Express migration guide, middleware patterns, and advanced features | Deep development, enterprise migration, production deployment |
-| **Example Project** | Complete working example with users/products APIs, AI integration, and JSDoc annotations | Learning by example, best practices reference |
+| **[Example Project](example-project/)** | Complete working example with users/products APIs, AI integration, and JSDoc annotations | Learning by example, best practices reference |
 
 ---
 


### PR DESCRIPTION
## Add Example Project Link

This PR adds a direct clickable link to the example-project directory in the Documentation Resources table.

### Changes Made:
- Added clickable link to `example-project/` directory in Documentation Resources table
- Users can now click to navigate directly to the example project
- Improves navigation and user experience for discovering examples

### Benefits:
- **Better Navigation**: Users can click directly to access the example project
- **Improved User Experience**: Easier discovery of working examples
- **Consistent Formatting**: Matches the format of other documentation links

### Files Changed:
- `README.md` - Added clickable link to example-project directory

This enhancement makes it easier for users to find and explore the complete working example.