### PR TITLE
ci: Add concurrency control to cancel previous runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
## Add Concurrency Control to Release Workflow

This PR adds concurrency control to the release workflow to prevent multiple workflows from running simultaneously.

### Problem:
- Multiple release workflows could run at the same time when multiple pushes occur
- This can cause resource conflicts and duplicate releases
- Previous runs continue even when newer commits are pushed

### Solution:
Added concurrency control with the following configuration:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

### Benefits:
- **Prevents Duplicate Runs**: Only one release workflow runs per branch at a time
- **Resource Efficiency**: Cancels previous runs when new commits are pushed
- **Cleaner CI**: Avoids conflicts and duplicate releases
- **Cost Optimization**: Reduces unnecessary CI resource usage

### How It Works:
- `group`: Creates a unique concurrency group based on workflow name and branch
- `cancel-in-progress: true`: Automatically cancels any running workflow when a new one starts
- Ensures only the latest commit triggers a release

### Files Changed:
- `.github/workflows/release.yml` - Added concurrency control

This ensures clean, efficient CI/CD pipeline execution without conflicts.