### PR TITLE
docs: Promote 'init' command as primary Quick Start method

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,6 +18,47 @@
 
 ---
 
+## **Quick Start**
+
+### ⚡ **Fastest Way to Get Started**
+
+For new projects, use the `init` command to create a complete, production-ready setup in seconds:
+
+```bash
+# Create a new project with everything configured
+npx easy-mcp-server init my-api-project
+
+cd my-api-project
+npm install
+./start.sh
+```
+
+**What You Get:**
+- ✅ **2 Working API Endpoints** - GET and POST examples with validation
+- ✅ **AI Integration** - MCP protocol pre-configured with prompts and resources
+- ✅ **Beautiful Landing Page** - Professional UI with feature showcase
+- ✅ **Complete Documentation** - OpenAPI spec, Swagger UI, and guides
+- ✅ **Hot Reload** - Real-time code updates during development
+- ✅ **Server Scripts** - `start.sh` and `stop.sh` for easy management
+- ✅ **MCP Bridge** - Pre-configured `mcp-bridge.json` with Chrome DevTools example
+- ✅ **Test Suite** - Test templates ready to expand
+- ✅ **Environment Config** - `.env` file with all settings documented
+
+**Your server is now running at:**
+- API Server: `http://localhost:8887`
+- Swagger Docs: `http://localhost:8887/docs`
+- MCP Server: `http://localhost:8888`
+
+**Next Steps:**
+1. Edit `api/` folder to add your endpoints
+2. Add AI prompts to `mcp/prompts/`
+3. Add documentation resources to `mcp/resources/`
+4. Customize `public/index.html` with your branding
+
+**🎯 You're production-ready from day one!**
+
+---
+
 ## **Express to easy-mcp-server Migration Guide**
 
 ### **Enterprise Migration Benefits**

--- a/LLM.txt
+++ b/LLM.txt
@@ -3,6 +3,28 @@
 ## Framework Overview
 easy-mcp-server is an enterprise-grade Node.js framework that automatically generates REST APIs, MCP tools, prompts, and resources from simple JavaScript classes. It provides AI models with comprehensive access to API functionality through the Model Context Protocol (MCP) 2024-11-05 standard, enabling seamless AI integration with convention-based development.
 
+## Quick Start for New Projects
+
+The fastest way to create a production-ready project:
+
+```bash
+npx easy-mcp-server init my-api-project
+cd my-api-project
+npm install
+./start.sh
+```
+
+This creates a complete project with:
+- Working API endpoints (GET & POST examples)
+- MCP integration (prompts, resources, tools)
+- Beautiful landing page
+- Complete documentation
+- Hot reload enabled
+- Server management scripts (start.sh, stop.sh)
+- MCP bridge configuration
+- Test suite template
+- Environment configuration
+
 ## Key LLM Integration Features
 
 ### Automatic MCP Tool Generation

--- a/README.md
+++ b/README.md
@@ -33,6 +33,30 @@
 
 ## **Quick Start**
 
+### ⚡ **Fastest Way: Create Your Own Project** (Recommended)
+```bash
+# Create a new project with everything configured
+npx easy-mcp-server init my-api-project
+cd my-api-project
+npm install
+./start.sh
+
+# Your API is now running at http://localhost:8887 🚀
+```
+
+**What you get instantly:**
+- ✅ Working API endpoints (GET & POST examples)
+- ✅ AI integration (MCP) pre-configured
+- ✅ Beautiful landing page
+- ✅ Complete documentation
+- ✅ Hot reload enabled
+- ✅ Scripts for easy server management (`start.sh`, `stop.sh`)
+- ✅ Test suite template
+
+**🎯 You're ready to build! Just edit `api/` folder to add your endpoints.**
+
+---
+
 ### Option 1: Try the Example Project
 ```bash
 # Clone and explore the complete example project
@@ -48,24 +72,7 @@ npx easy-mcp-server
 - JSDoc annotations for automated documentation
 - Real-world development patterns and best practices
 
-### Option 2: Create Your Own API (Quick Init)
-```bash
-# Initialize a new project with everything set up
-npx easy-mcp-server init my-api-project
-
-# Navigate to your project
-cd my-api-project
-
-# Install dependencies
-npm install
-
-# Start the server
-./start.sh
-# Or: npm start
-# Or: easy-mcp-server
-```
-
-### Option 3: Manual Setup
+### Option 2: Manual Setup
 ```bash
 # Install the framework
 npm install easy-mcp-server


### PR DESCRIPTION
## Summary
Prominently features the `easy-mcp-server init` command as the recommended Quick Start method across all major documentation files.

## Changes
- **README.md**: Moved init command to top as '⚡ Fastest Way (Recommended)'
- **DEVELOPMENT.md**: Added comprehensive Quick Start section at the beginning
- **LLM.txt**: Added Quick Start for New Projects section for AI assistants

## Benefits Highlighted
✅ Working API endpoints (GET & POST examples)
✅ AI integration (MCP) pre-configured
✅ Beautiful landing page
✅ Complete documentation
✅ Hot reload enabled
✅ Scripts for easy server management
✅ Test suite template
✅ Production-ready from day one

## Impact
- Improved developer onboarding experience
- Clearer path to getting started
- Consistent messaging across all docs
- Better visibility of the init feature