### PR TITLE
fix: Add npm link step in CI to resolve module resolution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Link package for local testing
+        run: npm link
+
       - name: Run tests
         run: npm test
 


### PR DESCRIPTION
## Problem  
18 dynamic route tests failing in CI but passing locally:
```
Cannot find module 'easy-mcp-server/base-api' from 'example-project/api/products/[id]/get.js'
```

## Root Cause
- example-project API files use `require('easy-mcp-server/base-api')`
- In CI, package isn't in node_modules (it's the repo being tested)
- Local environments typically have package linked/installed

## Solution
Add `npm link` step in CI workflow after `npm ci`:
```yaml
- name: Link package for local testing
  run: npm link
```

This makes the local package available as if installed from npm.

## Test Results
✅ **Local**: 460 passed, 6 skipped  
🔄 **CI**: Should fix all 18 failing tests

## Files Changed
- `.github/workflows/release.yml` - Added npm link step