### PR TITLE
fix: Link package in example-project for CI tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,9 @@ jobs:
         run: npm ci
 
       - name: Link package for local testing
-        run: npm link
+        run: |
+          npm link
+          cd example-project && npm link easy-mcp-server
 
       - name: Run tests
         run: npm test


### PR DESCRIPTION
## Problem
18 dynamic route tests still failing in CI after adding `npm link`:
```
Cannot find module 'easy-mcp-server/base-api' from 'example-project/api/products/[id]/get.js'
```

## Root Cause
- `npm link` created symlink globally but example-project couldn't resolve it
- require('easy-mcp-server/base-api') from example-project/api files failed
- Node.js module resolution looks in parent directories but global link wasn't accessible from example-project

## Solution
Run `npm link easy-mcp-server` in example-project directory after global link:
```yaml
- name: Link package for local testing
  run: |
    npm link
    cd example-project && npm link easy-mcp-server
```

This creates the symlink chain: example-project/node_modules -> global -> repo

## Test Results
✅ **Local**: 460 passed, 6 skipped
🔄 **CI**: Should fix all 18 failing tests

## Files Changed
- `.github/workflows/release.yml` - Added npm link in example-project