### PR TITLE
fix: Default to index.html for root route when public directory exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ EASY_MCP_SERVER_CORS_CREDENTIALS=true
 
 # Static File Serving (auto-enabled if directory exists)
 EASY_MCP_SERVER_STATIC_DIRECTORY=./public
-EASY_MCP_SERVER_DEFAULT_FILE=index.html  # Optional: serve this file at root path
+EASY_MCP_SERVER_DEFAULT_FILE=index.html  # Default file at root (defaults to index.html)
 
 # API Configuration
 EASY_MCP_SERVER_API_PATH=api

--- a/example-project/README.md
+++ b/example-project/README.md
@@ -38,7 +38,7 @@ EASY_MCP_SERVER_MCP_HOST=0.0.0.0       # MCP server host
 
 # Static Files (auto-enabled if directory exists)
 EASY_MCP_SERVER_STATIC_DIRECTORY=./public
-EASY_MCP_SERVER_DEFAULT_FILE=index.html  # Optional: serve at root path
+EASY_MCP_SERVER_DEFAULT_FILE=index.html  # Default file at root (defaults to index.html)
 ```
 
 You can modify `.env` to customize these settings. The `start.sh` script will automatically apply your changes.

--- a/src/easy-mcp-server.js
+++ b/src/easy-mcp-server.js
@@ -156,7 +156,7 @@ EASY_MCP_SERVER_MCP_HOST=0.0.0.0
 
 # Static File Serving (auto-enabled if directory exists)
 EASY_MCP_SERVER_STATIC_DIRECTORY=./public
-EASY_MCP_SERVER_DEFAULT_FILE=index.html  # Optional: serve this file at root
+EASY_MCP_SERVER_DEFAULT_FILE=index.html  # Default file at root (defaults to index.html)
 
 # CORS Configuration
 EASY_MCP_SERVER_CORS_ORIGIN=*

--- a/src/server.js
+++ b/src/server.js
@@ -44,7 +44,7 @@ app.use(express.urlencoded({ extended: true }));
 const fs = require('fs');
 const staticDirectory = process.env.EASY_MCP_SERVER_STATIC_DIRECTORY || './public';
 const staticPath = path.resolve(staticDirectory);
-const defaultFile = process.env.EASY_MCP_SERVER_DEFAULT_FILE;
+const defaultFile = process.env.EASY_MCP_SERVER_DEFAULT_FILE || 'index.html';
 
 // Auto-enable static file serving if public directory exists
 if (fs.existsSync(staticPath)) {
@@ -59,17 +59,13 @@ if (fs.existsSync(staticPath)) {
   }));
   console.log('✅ Static file middleware applied successfully');
   
-  // Handle root route with default file if explicitly configured
-  if (defaultFile) {
-    const indexPath = path.join(staticPath, defaultFile);
-    if (fs.existsSync(indexPath)) {
-      app.get('/', (req, res) => {
-        res.sendFile(indexPath);
-      });
-      console.log(`🏠 Root route configured: serving ${defaultFile}`);
-    } else {
-      console.log(`⚠️  EASY_MCP_SERVER_DEFAULT_FILE set to '${defaultFile}' but file not found`);
-    }
+  // Handle root route with default file (defaults to index.html)
+  const indexPath = path.join(staticPath, defaultFile);
+  if (fs.existsSync(indexPath)) {
+    app.get('/', (req, res) => {
+      res.sendFile(indexPath);
+    });
+    console.log(`🏠 Root route configured: serving ${defaultFile}`);
   }
 } else {
   console.log(`📁 Static files disabled: ${staticPath} not found`);


### PR DESCRIPTION
## Problem
CI test failing after PR #325:
```
FAIL test/static-file-serving.test.js
● Static File Serving - CI › Root Route Handling › should serve index.html at root route when it exists
expected 200 "OK", got 404 "Not Found"
```

## Root Cause
PR #325 simplified static file configuration but made root route file serving completely optional. The previous implementation required explicit `EASY_MCP_SERVER_DEFAULT_FILE` to serve a default file at root.

However:
- Standard web servers (nginx, Apache, etc.) default to `index.html`
- The test expected this standard behavior
- Users expect `public/index.html` to automatically serve at `/`

## Solution
**Default `EASY_MCP_SERVER_DEFAULT_FILE` to `'index.html'`** if not explicitly set.

### New Behavior:
1. ✅ If `./public` directory exists → enable static file serving
2. ✅ If `./public/index.html` exists → automatically serve at root route
3. ✅ If `EASY_MCP_SERVER_DEFAULT_FILE` is set → use that file instead
4. ✅ Maintains convention-over-configuration philosophy

### Code Change:
```javascript
// Before (PR #325):
const defaultFile = process.env.EASY_MCP_SERVER_DEFAULT_FILE;

// After (this fix):
const defaultFile = process.env.EASY_MCP_SERVER_DEFAULT_FILE || 'index.html';
```

## Testing
✅ All 460 tests passing locally  
✅ Fixed failing `static-file-serving.test.js` test  
✅ Maintains standard web server behavior  

## Files Changed
- `src/server.js` - Default to `index.html`
- `README.md` - Updated documentation
- `src/easy-mcp-server.js` - Updated .env template
- `example-project/README.md` - Updated examples

## Migration Impact
✅ **No breaking changes**  
✅ **Improves user experience** - matches standard web server behavior  
✅ **Maintains flexibility** - users can still override with env var  