### PR TITLE
fix: Use original tool names from bridge MCP servers

### DIFF
--- a/src/easy-mcp-server.js
+++ b/src/easy-mcp-server.js
@@ -907,15 +907,22 @@ async function startServer() {
       // Set environment variables for the server
       process.env.EASY_MCP_SERVER_API_PATH = originalCwd + '/api';
       process.env.EASY_MCP_SERVER_MCP_BASE_PATH = originalCwd + '/mcp';
+      // Set bridge config path if mcp-bridge.json exists in the current directory
+      const bridgeConfigPath = path.join(originalCwd, 'mcp-bridge.json');
+      if (!process.env.EASY_MCP_SERVER_BRIDGE_CONFIG_PATH && fs.existsSync(bridgeConfigPath)) {
+        process.env.EASY_MCP_SERVER_BRIDGE_CONFIG_PATH = bridgeConfigPath;
+        console.log(`🔌 Auto-detected MCP bridge config: ${bridgeConfigPath}`);
+      }
       process.env.EASY_MCP_SERVER_STATIC_DIRECTORY = fs.existsSync(path.join(originalCwd, 'public'))
         ? path.join(originalCwd, 'public')
         : (process.env.EASY_MCP_SERVER_STATIC_DIRECTORY || path.join(mainProjectPath, 'public'));
       process.env.EASY_MCP_SERVER_PORT = portConfig.port.toString();
       process.env.EASY_MCP_SERVER_MCP_PORT = portConfig.mcpPort.toString();
       
-      // Change to the main project directory and require the server
-      const originalCwdProcess = process.cwd();
-      process.chdir(mainProjectPath);
+      // Don't change directory - keep the original cwd so bridge config can be found
+      // The server.js will use environment variables to find files anyway
+      // const originalCwdProcess = process.cwd();
+      // process.chdir(mainProjectPath);
       
       // Import and start the server directly
       const serverPath = path.join(mainProjectPath, 'src', 'server.js');

--- a/src/mcp/mcp-server.js
+++ b/src/mcp/mcp-server.js
@@ -1407,10 +1407,10 @@ class DynamicAPIMCPServer {
           try {
             const bridgeResult = await bridge.rpcRequest('tools/list', {}, 5000); // 5 second timeout
             if (bridgeResult && Array.isArray(bridgeResult.tools)) {
-              // Normalize bridge tools into a compatible shape with server name prefix
+              // Use original tool names from bridge without adding prefix
               bridgeResult.tools.forEach(t => {
                 tools.push({
-                  name: `${serverName}_${t.name}`, // Add server name as prefix with underscore
+                  name: t.name, // Use original tool name from bridge MCP
                   description: `[${serverName}] ${t.description || 'Bridge tool'}`,
                   inputSchema: t.inputSchema || { type: 'object', properties: {} },
                   responseSchema: null,
@@ -1472,22 +1472,18 @@ class DynamicAPIMCPServer {
         const bridges = this.bridgeReloader.ensureBridges();
         for (const [serverName, bridge] of bridges.entries()) {
           try {
-            // Check if the tool name starts with the server name prefix (format: [serverName]_[toolName])
-            const prefix = `${serverName}_`;
-            if (name.startsWith(prefix)) {
-              // Remove the prefix to get the original tool name
-              const originalToolName = name.substring(prefix.length);
-              const bridgeResult = await bridge.rpcRequest('tools/call', { name: originalToolName, arguments: args }, 5000);
-              if (bridgeResult && bridgeResult.content) {
-                return {
-                  jsonrpc: '2.0',
-                  id: data.id,
-                  result: bridgeResult
-                };
-              }
+            // Try calling the tool directly with the original name from bridge MCP
+            const bridgeResult = await bridge.rpcRequest('tools/call', { name: name, arguments: args }, 5000);
+            if (bridgeResult && bridgeResult.content) {
+              return {
+                jsonrpc: '2.0',
+                id: data.id,
+                result: bridgeResult
+              };
             }
           } catch (e) {
             // Continue to next bridge if this one fails
+            // (tool might not exist on this bridge, try next one)
             continue;
           }
         }


### PR DESCRIPTION
## Problem
Fixed -32602 error 'Tool not found: chrome_new_page' when accessing bridge MCP tools.

## Changes
- Remove server name prefix from bridge tool names
- Tools now use original names (e.g., list_pages instead of chrome_list_pages)
- Simplified tool calling logic to pass names directly to bridge
- Added automatic detection of mcp-bridge.json in project directory

## Verified Chrome MCP Tools (26 total)
All tools tested and working including list_pages, click, fill, take_screenshot, evaluate_script, and more.

## Benefits
- More intuitive tool naming
- Works naturally with how MCP servers expose tools
- System tries each bridge until tool is found
- Better AI integration