### PR TITLE
fix: Update test to match new tool naming convention

### DIFF
--- a/test/mcp.tools.merge-bridge.test.js
+++ b/test/mcp.tools.merge-bridge.test.js
@@ -40,7 +40,8 @@ describe('MCP tools/list merges bridge tools (HTTP MCP)', () => {
     const resp = await mcpServer.processMCPRequest({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
     expect(resp && resp.result && Array.isArray(resp.result.tools)).toBe(true);
     const names = resp.result.tools.map(t => t.name);
-    expect(names).toContain('mock_mock_bridge_tool');
+    // Tool names no longer have double prefixes - clean names are used
+    expect(names).toContain('mock_bridge_tool');
   });
 });
 


### PR DESCRIPTION
## Fix

Updates the test  to expect the new clean tool naming convention introduced in #331.

## Changes

- Test now expects  instead of 
- Adds comment explaining the change to clean names without double prefixes

## Context

The MCP Schema Adapter changes in #331 cleaned up tool naming by removing double prefixes. This test was expecting the old naming format and needs to be updated.