### PR TITLE
fix: Correct module paths in test files

### DIFF
--- a/test/api-response-utils.test.js
+++ b/test/api-response-utils.test.js
@@ -2,7 +2,7 @@
  * Tests for APIResponseUtils
  */
 
-const APIResponseUtils = require('../src/lib/api-response-utils');
+const APIResponseUtils = require('../src/lib/api/api-response-utils');
 
 describe('APIResponseUtils', () => {
   let mockRes;

--- a/test/base-api-enhanced.test.js
+++ b/test/base-api-enhanced.test.js
@@ -6,11 +6,11 @@ const BaseAPIEnhanced = require('../src/lib/api/base-api-enhanced');
 
 // Mock dependencies
 jest.mock('../src/utils/logger');
-jest.mock('../src/lib/llm-service');
+jest.mock('../src/lib/llm/llm-service');
 jest.mock('../src/utils/resource-loader');
 
 // Mock LLM service
-const { createLLMService } = require('../src/lib/llm-service');
+const { createLLMService } = require('../src/lib/llm/llm-service');
 createLLMService.mockImplementation(() => ({
   initialize: jest.fn().mockResolvedValue(),
   generate: jest.fn().mockResolvedValue('Mock response'),


### PR DESCRIPTION
## Summary

Fixes GitHub Actions test failures caused by incorrect module paths in test files.

## Changes

- ✅ Fixed llm-service path: `lib/llm-service` → `lib/llm/llm-service`
- ✅ Fixed api-response-utils path: `lib/api-response-utils` → `lib/api/api-response-utils`

## Test Results

- ✅ All tests in `base-api-enhanced.test.js` pass
- ✅ All tests in `api-response-utils.test.js` pass

This should resolve the GitHub Actions failures where modules could not be found during test execution.