### PR TITLE
fix: Correct all test module paths and file references

### DIFF
--- a/test/error-handling.test.js
+++ b/test/error-handling.test.js
@@ -63,7 +63,7 @@ describe('Error Handling Improvements', () => {
 
       // Test that the server fails when trying to use an occupied port
       const { spawn } = require('child_process');
-      const serverProcess = spawn('node', ['bin/easy-mcp-server.js'], {
+      const serverProcess = spawn('node', [path.join(__dirname, '..', 'src', 'easy-mcp-server.js')], {
         cwd: path.join(__dirname, '..'),
         env: { ...process.env, EASY_MCP_SERVER_PORT: testPort.toString() }
       });

--- a/test/graceful-initialization.test.js
+++ b/test/graceful-initialization.test.js
@@ -210,7 +210,7 @@ describe('Graceful API Initialization', () => {
       const path = require('path');
       
       const failingApiCode = `
-const BaseAPIEnhanced = require('../../src/lib/api/base-api-enhanced');
+const BaseAPIEnhanced = require('easy-mcp-server/lib/api/base-api-enhanced');
 
 class FailingTestAPI extends BaseAPIEnhanced {
   async _initializeLLM() {
@@ -228,7 +228,7 @@ module.exports = FailingTestAPI;
       // Create temp directory
       const tempDir = path.join(__dirname, 'temp-api');
       if (!fs.existsSync(tempDir)) {
-        fs.mkdirSync(tempDir);
+        fs.mkdirSync(tempDir, { recursive: true });
       }
       
       fs.writeFileSync(path.join(tempDir, 'get.js'), failingApiCode);


### PR DESCRIPTION
## Summary

Fixes remaining GitHub Actions test failures by correcting module paths in test files.

## Changes

- ✅ Fixed `error-handling.test.js` - Changed `bin/easy-mcp-server.js` to correct path `src/easy-mcp-server.js`
- ✅ Fixed `graceful-initialization.test.js` - Changed relative path to package import for dynamically generated test code

## Issues Fixed

- Module resolution errors when test code is dynamically generated
- Incorrect file paths in spawn commands

This should resolve the remaining test failures in GitHub Actions.