### PR TITLE
fix: Remove package imports from test source code strings

### DIFF
--- a/test/graceful-initialization.test.js
+++ b/test/graceful-initialization.test.js
@@ -210,7 +210,7 @@ describe('Graceful API Initialization', () => {
       const path = require('path');
       
       const failingApiCode = `
-const BaseAPIEnhanced = require('easy-mcp-server/lib/api/base-api-enhanced');
+const BaseAPIEnhanced = require('../../src/lib/api/base-api-enhanced');
 
 class FailingTestAPI extends BaseAPIEnhanced {
   async _initializeLLM() {

--- a/test/integration-response-schema.test.js
+++ b/test/integration-response-schema.test.js
@@ -36,8 +36,6 @@ describe('@responseSchema Integration Tests', () => {
     test('should process @responseSchema annotation through entire pipeline', () => {
       // 1. Create source code with @responseSchema annotation
       const sourceCode = `
-        const BaseAPI = require('easy-mcp-server/base-api');
-
         /**
          * @description Create a new user with validation
          * @summary Create user endpoint
@@ -73,7 +71,7 @@ describe('@responseSchema Integration Tests', () => {
          *   "409": { "description": "User already exists", "schema": { "type": "object", "properties": { "error": { "type": "string" } } } }
          * }
          */
-        class TestUserAPI extends BaseAPI {
+        class TestUserAPI {
           process(req, res) {
             // Implementation
           }
@@ -175,8 +173,6 @@ describe('@responseSchema Integration Tests', () => {
     test('should not override @responseSchema with auto-generated schemas', () => {
       // Create source code with only @responseSchema (no @errorResponses)
       const sourceCode = `
-        const BaseAPI = require('easy-mcp-server/base-api');
-
         /**
          * @responseSchema {
          *   "type": "object",
@@ -186,7 +182,7 @@ describe('@responseSchema Integration Tests', () => {
          *   }
          * }
          */
-        class TestCustomAPI extends BaseAPI {
+        class TestCustomAPI {
           process(req, res) {
             // Implementation
           }
@@ -249,12 +245,10 @@ describe('@responseSchema Integration Tests', () => {
     test('should fall back to auto-generation when no annotations present', () => {
       // Create source code with no @responseSchema
       const sourceCode = `
-        const BaseAPI = require('easy-mcp-server/base-api');
-
         /**
          * @description Simple endpoint without response schema
          */
-        class TestSimpleAPI extends BaseAPI {
+        class TestSimpleAPI {
           process(req, res) {
             // Implementation
           }
@@ -300,8 +294,6 @@ describe('@responseSchema Integration Tests', () => {
   describe('Edge Cases and Error Handling', () => {
     test('should handle malformed @responseSchema gracefully', () => {
       const sourceCode = `
-        const BaseAPI = require('easy-mcp-server/base-api');
-
         /**
          * @responseSchema {
          *   "type": "object",
@@ -310,7 +302,7 @@ describe('@responseSchema Integration Tests', () => {
          *   }
          * }
          */
-        class TestMalformedAPI extends BaseAPI {
+        class TestMalformedAPI {
           process(req, res) {
             // Implementation
           }
@@ -366,8 +358,6 @@ describe('@responseSchema Integration Tests', () => {
 
     test('should handle mixed valid and invalid annotations', () => {
       const sourceCode = `
-        const BaseAPI = require('easy-mcp-server/base-api');
-
         /**
          * @description Valid description
          * @summary Valid summary
@@ -385,7 +375,7 @@ describe('@responseSchema Integration Tests', () => {
          *   }
          * }
          */
-        class TestMixedAPI extends BaseAPI {
+        class TestMixedAPI {
           process(req, res) {
             // Implementation
           }


### PR DESCRIPTION
Fixes GitHub Actions failure: 'Class extends value [object Object] is not a constructor'

Changes:
- Removed require('easy-mcp-server/base-api') from source code strings in integration-response-schema.test.js (these are only used for annotation parsing, not execution)
- Changed package import to relative path in graceful-initialization.test.js for code that gets executed

These source code strings are causing module resolution issues in the GitHub Actions CI environment when the package is linked.