### PR TITLE
fix: Fix test failures in openapi-mcp-swagger-details and mcp-inspector-stability

### DIFF
--- a/test/mcp-inspector-stability.test.js
+++ b/test/mcp-inspector-stability.test.js
@@ -5,8 +5,11 @@ jest.resetModules();
 const request = require('supertest');
 const http = require('http');
 
-// Boot the server app (this also starts MCP server at EASY_MCP_SERVER_MCP_PORT)
-const { app } = require('../src/app/server');
+// Boot the server app (Express server)
+const { app, apiLoader } = require('../src/app/server');
+
+// Import MCP server
+const DynamicAPIMCPServer = require('../src/mcp');
 
 async function postJSON(url, payload) {
   return new Promise((resolve, reject) => {
@@ -35,9 +38,33 @@ async function postJSON(url, payload) {
 }
 
 describe('MCP Inspector stability - tool schemas persist across selections', () => {
+  let mcpServer;
+  
   beforeAll(async () => {
-    // warm up express endpoints
+    // Warm up express endpoints
     await request(app).get('/openapi.json').expect(200);
+    
+    // Start MCP server manually (like other tests do)
+    const mcpPort = parseInt(process.env.EASY_MCP_SERVER_MCP_PORT) || 8888;
+    const routes = apiLoader.getRoutes();
+    
+    mcpServer = new DynamicAPIMCPServer('127.0.0.1', mcpPort, {
+      mcp: {
+        basePath: require('path').join(__dirname, '..', 'example-project', 'mcp')
+      }
+    });
+    
+    mcpServer.setRoutes(routes);
+    await mcpServer.run();
+    
+    // Wait a bit for server to be fully ready
+    await new Promise(resolve => setTimeout(resolve, 200));
+  });
+  
+  afterAll(async () => {
+    if (mcpServer) {
+      await mcpServer.stop();
+    }
   });
 
   test('HTTP /mcp/tools keeps query.active for api__users_get across repeated calls', async () => {
@@ -53,18 +80,26 @@ describe('MCP Inspector stability - tool schemas persist across selections', () 
   });
 
   test('JSON-RPC /mcp tools/list keeps query.active for api__users_get after interleaved calls', async () => {
-    const mcpUrl = 'http://127.0.0.1:8888/mcp';
+    const mcpPort = parseInt(process.env.EASY_MCP_SERVER_MCP_PORT) || 8888;
+    const mcpUrl = `http://127.0.0.1:${mcpPort}/mcp`;
     const list = async () => postJSON(mcpUrl, { jsonrpc: '2.0', id: 1, method: 'tools/list' });
     // 1) initial list
     let r = await list();
     const find = name => r && r.result && Array.isArray(r.result.tools) && r.result.tools.find(t => t.name === name);
-    expect(find('api__users_get').inputSchema.properties.query.properties.active).toBeDefined();
+    const usersGetTool = find('api__users_get');
+    expect(usersGetTool).toBeDefined();
+    expect(usersGetTool.inputSchema).toBeDefined();
+    expect(usersGetTool.inputSchema.properties).toBeDefined();
+    expect(usersGetTool.inputSchema.properties.query).toBeDefined();
+    expect(usersGetTool.inputSchema.properties.query.properties.active).toBeDefined();
     // 2) simulate selecting another tool (no-op, but we re-list)
     r = await list();
     expect(find('api__users_post')).toBeDefined();
     // 3) list again and re-check users_get
     r = await list();
-    expect(find('api__users_get').inputSchema.properties.query.properties.active).toBeDefined();
+    const usersGetTool2 = find('api__users_get');
+    expect(usersGetTool2).toBeDefined();
+    expect(usersGetTool2.inputSchema.properties.query.properties.active).toBeDefined();
   });
 });
 

--- a/test/openapi-mcp-swagger-details.test.js
+++ b/test/openapi-mcp-swagger-details.test.js
@@ -51,7 +51,8 @@ describe('OpenAPI, MCP, and Swagger details', () => {
     });
 
     test('GET /products/:id returns Product object', () => {
-      const product = spec.paths['/products/:id'].get.responses['200'].content['application/json'].schema.properties.product;
+      // OpenAPI generator converts Express paths (:id) to OpenAPI format ({id})
+      const product = spec.paths['/products/{id}'].get.responses['200'].content['application/json'].schema.properties.product;
       expect(product).toBeDefined();
       expect(product.properties.id).toBeDefined();
       expect(product.properties.name).toBeDefined();


### PR DESCRIPTION
Fixes several test failures:

1. **openapi-mcp-swagger-details.test.js**: Fixed path format - OpenAPI uses `{id}` format, not `:id` Express format
2. **mcp-inspector-stability.test.js**: Fixed MCP server startup - now manually starts MCP server in test instead of relying on startServer() which tries to start Express HTTP server

The mcp-inspector-stability test still has one failure related to MCP server's tools/list not returning query schemas, but this appears to be a deeper server implementation issue that needs separate investigation.