### PR TITLE
fix: Add lazy initialization for mcpRequestProcessor in deprecated methods

### DIFF
--- a/src/mcp/core/mcp-server.js
+++ b/src/mcp/core/mcp-server.js
@@ -1342,6 +1342,18 @@ class DynamicAPIMCPServer {
    * @deprecated Use this.mcpRequestProcessor.processListPrompts() instead
    */
   async processListPrompts(data) {
+    if (!this.mcpRequestProcessor) {
+      this.mcpRequestProcessor = new MCPRequestProcessor(this, {
+        toolBuilder: this.toolBuilder,
+        toolExecutor: this.toolExecutor,
+        promptHandler: this.promptHandler,
+        resourceHandler: this.resourceHandler,
+        schemaNormalizer: this.schemaNormalizer,
+        getLoadedRoutes: this.getLoadedRoutes.bind(this),
+        trackRequest: this.trackRequest.bind(this),
+        handleError: this.handleError.bind(this)
+      });
+    }
     return this.mcpRequestProcessor.processListPrompts(data);
   }
   
@@ -1391,6 +1403,18 @@ class DynamicAPIMCPServer {
    * @deprecated Use this.mcpRequestProcessor.processGetPrompt() instead
    */
   async processGetPrompt(data) {
+    if (!this.mcpRequestProcessor) {
+      this.mcpRequestProcessor = new MCPRequestProcessor(this, {
+        toolBuilder: this.toolBuilder,
+        toolExecutor: this.toolExecutor,
+        promptHandler: this.promptHandler,
+        resourceHandler: this.resourceHandler,
+        schemaNormalizer: this.schemaNormalizer,
+        getLoadedRoutes: this.getLoadedRoutes.bind(this),
+        trackRequest: this.trackRequest.bind(this),
+        handleError: this.handleError.bind(this)
+      });
+    }
     return this.mcpRequestProcessor.processGetPrompt(data);
   }
   
@@ -1461,6 +1485,18 @@ class DynamicAPIMCPServer {
    * @deprecated Use this.mcpRequestProcessor.processListResources() instead
    */
   async processListResources(data) {
+    if (!this.mcpRequestProcessor) {
+      this.mcpRequestProcessor = new MCPRequestProcessor(this, {
+        toolBuilder: this.toolBuilder,
+        toolExecutor: this.toolExecutor,
+        promptHandler: this.promptHandler,
+        resourceHandler: this.resourceHandler,
+        schemaNormalizer: this.schemaNormalizer,
+        getLoadedRoutes: this.getLoadedRoutes.bind(this),
+        trackRequest: this.trackRequest.bind(this),
+        handleError: this.handleError.bind(this)
+      });
+    }
     return this.mcpRequestProcessor.processListResources(data);
   }
   
@@ -1656,6 +1692,18 @@ class DynamicAPIMCPServer {
    * @deprecated Use this.mcpRequestProcessor.processReadResource() instead
    */
   async processReadResource(data) {
+    if (!this.mcpRequestProcessor) {
+      this.mcpRequestProcessor = new MCPRequestProcessor(this, {
+        toolBuilder: this.toolBuilder,
+        toolExecutor: this.toolExecutor,
+        promptHandler: this.promptHandler,
+        resourceHandler: this.resourceHandler,
+        schemaNormalizer: this.schemaNormalizer,
+        getLoadedRoutes: this.getLoadedRoutes.bind(this),
+        trackRequest: this.trackRequest.bind(this),
+        handleError: this.handleError.bind(this)
+      });
+    }
     return this.mcpRequestProcessor.processReadResource(data);
   }
   
@@ -1996,6 +2044,18 @@ class DynamicAPIMCPServer {
    * @deprecated Use this.mcpRequestProcessor.processHealth() instead
    */
   async processHealth(data) {
+    if (!this.mcpRequestProcessor) {
+      this.mcpRequestProcessor = new MCPRequestProcessor(this, {
+        toolBuilder: this.toolBuilder,
+        toolExecutor: this.toolExecutor,
+        promptHandler: this.promptHandler,
+        resourceHandler: this.resourceHandler,
+        schemaNormalizer: this.schemaNormalizer,
+        getLoadedRoutes: this.getLoadedRoutes.bind(this),
+        trackRequest: this.trackRequest.bind(this),
+        handleError: this.handleError.bind(this)
+      });
+    }
     return this.mcpRequestProcessor.processHealth(data);
   }
   
@@ -2050,6 +2110,18 @@ class DynamicAPIMCPServer {
    * @deprecated Use this.mcpRequestProcessor.processMetrics() instead
    */
   async processMetrics(data) {
+    if (!this.mcpRequestProcessor) {
+      this.mcpRequestProcessor = new MCPRequestProcessor(this, {
+        toolBuilder: this.toolBuilder,
+        toolExecutor: this.toolExecutor,
+        promptHandler: this.promptHandler,
+        resourceHandler: this.resourceHandler,
+        schemaNormalizer: this.schemaNormalizer,
+        getLoadedRoutes: this.getLoadedRoutes.bind(this),
+        trackRequest: this.trackRequest.bind(this),
+        handleError: this.handleError.bind(this)
+      });
+    }
     return this.mcpRequestProcessor.processMetrics(data);
   }
   

--- a/test/mcp-auto-discovery.test.js
+++ b/test/mcp-auto-discovery.test.js
@@ -168,7 +168,8 @@ This is a test markdown resource with **bold** and *italic* text.
       expect(mcpServer.resources.has('resource://test.md')).toBe(true);
       const resource = mcpServer.resources.get('resource://test.md');
       expect(resource.name).toBe('test');
-      expect(resource.mimeType).toBe('text/markdown');
+      // MIME type may include charset parameter
+      expect(resource.mimeType).toMatch(/^text\/markdown(;|$)/);
       expect(resource.content).toContain('# Test Markdown Resource');
     });
 
@@ -184,7 +185,8 @@ No special formatting is applied.`;
       expect(mcpServer.resources.has('resource://test.txt')).toBe(true);
       const resource = mcpServer.resources.get('resource://test.txt');
       expect(resource.name).toBe('test');
-      expect(resource.mimeType).toBe('text/plain');
+      // MIME type may include charset parameter
+      expect(resource.mimeType).toMatch(/^text\/plain(;|$)/);
       expect(resource.content).toContain('This is a plain text resource.');
     });
   });


### PR DESCRIPTION
Fixes tests failing with 'Cannot read properties of null' errors:

- Added lazy initialization for processListPrompts, processGetPrompt, processListResources, processReadResource, processHealth, and processMetrics methods
- Allows tests to call these deprecated methods without needing to call run() first
- Fixed MIME type expectations in mcp-auto-discovery test to account for charset parameter

Fixes: prompts-resources.test.js, mcp-enhanced-monitoring.test.js, mcp-auto-discovery.test.js