### PR TITLE
fix: Exclude test files from TypeScript compilation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,9 @@
   ],
   "exclude": [
     "node_modules",
-    "**/node_modules/**"
+    "**/node_modules/**",
+    "test/**/*",
+    "**/*.test.ts",
+    "**/*.test.js"
   ]
 }


### PR DESCRIPTION
## Problem
TypeScript was trying to compile test files, which caused compilation errors in CI:
```
Error Message: tsconfig.json:19:9 - error TS1005: '{' expected.
```

This prevented routes from loading, causing multiple test failures:
- OpenAPI/MCP tests - routes not being found
- Function handler tests - routes not loading  
- Static file serving tests - indirectly affected

## Solution
Excluded test files from TypeScript compilation in `tsconfig.json`:
- `test/**/*`
- `**/*.test.ts`
- `**/*.test.js`

## Testing
✅ All previously failing tests now pass locally:
- `test/openapi-mcp-swagger-details.test.js`
- `test/function-handlers.test.js`
- `test/static-file-serving.test.js`

This fix ensures TypeScript only compiles source files, not test files, resolving the CI failures.