### PR TITLE
fix: Explicitly configure ts-node to use tsconfig.json

### DIFF
--- a/src/app/server.js
+++ b/src/app/server.js
@@ -1,13 +1,17 @@
 require('dotenv').config();
 // Enable TypeScript API loading (compile TS only, ignore JS)
+const path = require('path');
 try {
-  require('ts-node').register({ transpileOnly: true, compilerOptions: { allowJs: false, module: 'commonjs', target: 'ES2020' } });
+  require('ts-node').register({ 
+    transpileOnly: true, 
+    project: path.join(__dirname, '..', 'tsconfig.json'),
+    compilerOptions: { allowJs: false, module: 'commonjs', target: 'ES2020' } 
+  });
 } catch (_) { /* optional */ }
 const express = require('express');
 const cors = require('cors');
 
 // Import core modules
-const path = require('path');
 const APILoader = require(path.join(__dirname, '..', 'core', 'api-loader'));
 const OpenAPIGenerator = require(path.join(__dirname, '..', 'core', 'openapi-generator'));
 const DynamicAPIMCPServer = require(path.join(__dirname, '..', 'mcp'));

--- a/src/core/api-loader.js
+++ b/src/core/api-loader.js
@@ -6,7 +6,12 @@
 const fs = require('fs');
 const path = require('path');
 // Ensure TypeScript files can be required when present
-try { require('ts-node/register/transpile-only'); } catch (_) { /* optional at runtime/tests */ }
+try { 
+  require('ts-node').register({ 
+    transpileOnly: true,
+    project: path.join(__dirname, '..', 'tsconfig.json')
+  }); 
+} catch (_) { /* optional at runtime/tests */ }
 const { apiSpecTs } = require('../utils/api/openapi-helper');
 const { apiSpec, queryParam, tsSchema } = require('../utils/api/openapi-helper');
 


### PR DESCRIPTION
## Problem
TypeScript was still trying to compile test files in CI even after excluding them in tsconfig.json. The error was:
```
Error Message: tsconfig.json:19:9 - error TS1005: '{' expected.
  19         class TestMixedAPI {
```

The issue was that `ts-node` wasn't explicitly configured to use the tsconfig.json file, so it wasn't respecting the exclude patterns.

## Solution
Explicitly configure `ts-node` to use the tsconfig.json file in both:
- `src/app/server.js` - server initialization
- `src/core/api-loader.js` - API loading

By specifying the `project` option, ts-node will now properly respect the excludes defined in tsconfig.json.

## Changes
- Update `server.js` to use `project` path in ts-node.register()
- Update `api-loader.js` to use `project` path instead of basic register
- Fix duplicate `path` require in server.js

## Testing
✅ Tests pass locally:
- `test/openapi-mcp-swagger-details.test.js`
- `test/function-handlers.test.js`

This should fix the remaining CI failures where routes weren't loading due to TypeScript compilation errors.