### PR TITLE
fix: Add ignore pattern to ts-node to skip test files

### DIFF
--- a/src/app/server.js
+++ b/src/app/server.js
@@ -5,7 +5,14 @@ try {
   require('ts-node').register({ 
     transpileOnly: true, 
     project: path.join(__dirname, '..', 'tsconfig.json'),
-    compilerOptions: { allowJs: false, module: 'commonjs', target: 'ES2020' } 
+    ignore: ['(?:^|/)test/'],
+    compilerOptions: { 
+      allowJs: false, 
+      module: 'commonjs', 
+      target: 'ES2020',
+      skipLibCheck: true,
+      skipDefaultLibCheck: true
+    } 
   });
 } catch (_) { /* optional */ }
 const express = require('express');

--- a/src/core/api-loader.js
+++ b/src/core/api-loader.js
@@ -9,7 +9,12 @@ const path = require('path');
 try { 
   require('ts-node').register({ 
     transpileOnly: true,
-    project: path.join(__dirname, '..', 'tsconfig.json')
+    project: path.join(__dirname, '..', 'tsconfig.json'),
+    ignore: ['(?:^|/)test/'],
+    compilerOptions: {
+      skipLibCheck: true,
+      skipDefaultLibCheck: true
+    }
   }); 
 } catch (_) { /* optional at runtime/tests */ }
 const { apiSpecTs } = require('../utils/api/openapi-helper');


### PR DESCRIPTION
## Problem
TypeScript was still trying to compile test files in CI even after:
1. Excluding test files in tsconfig.json
2. Explicitly configuring ts-node to use tsconfig.json

The error persisted:
```
Error Message: tsconfig.json:19:9 - error TS1005: '{' expected.
```

## Solution
Add explicit `ignore` pattern to `ts-node.register()` to prevent ts-node from even attempting to compile files in the test directory. This is a runtime-level exclusion that works alongside tsconfig.json excludes.

## Changes
- Add `ignore: ['(?:^|/)test/']` to ts-node.register() in both:
  - `src/app/server.js`
  - `src/core/api-loader.js`
- Add `skipLibCheck` and `skipDefaultLibCheck` to compilerOptions for better performance

## Testing
✅ Tests pass locally:
- `test/openapi-mcp-swagger-details.test.js`
- `test/function-handlers.test.js`

The ignore pattern prevents ts-node from processing any files in test directories during runtime compilation, which should resolve the CI failures.