### PR TITLE
fix: Use regex patterns for ts-node ignore option

### DIFF
--- a/src/app/server.js
+++ b/src/app/server.js
@@ -5,7 +5,13 @@ try {
   require('ts-node').register({ 
     transpileOnly: true, 
     project: path.join(__dirname, '..', 'tsconfig.json'),
-    ignore: ['(?:^|/)test/'],
+    skipIgnore: false,
+    ignore: [
+      /.*\/test\/.*/,
+      /.*\/__tests__\/.*/,
+      /.*\.test\.ts$/,
+      /.*\.spec\.ts$/
+    ],
     compilerOptions: { 
       allowJs: false, 
       module: 'commonjs', 

--- a/src/core/api-loader.js
+++ b/src/core/api-loader.js
@@ -10,7 +10,13 @@ try {
   require('ts-node').register({ 
     transpileOnly: true,
     project: path.join(__dirname, '..', 'tsconfig.json'),
-    ignore: ['(?:^|/)test/'],
+    skipIgnore: false,
+    ignore: [
+      /.*\/test\/.*/,
+      /.*\/__tests__\/.*/,
+      /.*\.test\.ts$/,
+      /.*\.spec\.ts$/
+    ],
     compilerOptions: {
       skipLibCheck: true,
       skipDefaultLibCheck: true


### PR DESCRIPTION
## Problem
TypeScript was still trying to compile test files in CI despite previous fixes.
The ignore patterns weren't working because ts-node's `ignore` option requires
regex patterns, not string patterns.

## Solution
Update both files to use proper regex patterns for the ignore option:
- `/.*\/test\/.*/` - matches any file in a test directory
- `/.*\/__tests__\/.*/` - matches any file in __tests__ directory
- `/.*\.test\.ts$/` - matches any .test.ts file
- `/.*\.spec\.ts$/` - matches any .spec.ts file

Also add `skipIgnore: false` to ensure ignore patterns are respected.

## Changes
- Update `src/app/server.js` - use regex patterns for ignore
- Update `src/core/api-loader.js` - use regex patterns for ignore

## Testing
✅ Tests pass locally:
- `test/openapi-mcp-swagger-details.test.js`
- `test/function-handlers.test.js`

This should properly prevent ts-node from compiling test files in CI.