### PR TITLE
fix: Use separate tsconfig.runtime.json to exclude test files

### DIFF
--- a/src/app/server.js
+++ b/src/app/server.js
@@ -4,14 +4,7 @@ const path = require('path');
 try {
   require('ts-node').register({ 
     transpileOnly: true, 
-    project: path.join(__dirname, '..', 'tsconfig.json'),
-    skipIgnore: false,
-    ignore: [
-      /.*\/test\/.*/,
-      /.*\/__tests__\/.*/,
-      /.*\.test\.ts$/,
-      /.*\.spec\.ts$/
-    ],
+    project: path.join(__dirname, '..', 'tsconfig.runtime.json'),
     compilerOptions: { 
       allowJs: false, 
       module: 'commonjs', 

--- a/src/core/api-loader.js
+++ b/src/core/api-loader.js
@@ -9,14 +9,7 @@ const path = require('path');
 try { 
   require('ts-node').register({ 
     transpileOnly: true,
-    project: path.join(__dirname, '..', 'tsconfig.json'),
-    skipIgnore: false,
-    ignore: [
-      /.*\/test\/.*/,
-      /.*\/__tests__\/.*/,
-      /.*\.test\.ts$/,
-      /.*\.spec\.ts$/
-    ],
+    project: path.join(__dirname, '..', 'tsconfig.runtime.json'),
     compilerOptions: {
       skipLibCheck: true,
       skipDefaultLibCheck: true

--- a/tsconfig.runtime.json
+++ b/tsconfig.runtime.json
@@ -1,0 +1,26 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "noResolve": false
+  },
+  "include": [
+    "src/**/*",
+    "example-project/**/*",
+    "types/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/node_modules/**",
+    "test/**/*",
+    "**/test/**/*",
+    "**/*.test.ts",
+    "**/*.test.js",
+    "**/*.spec.ts",
+    "**/*.spec.js",
+    "**/__tests__/**/*",
+    "**/__test__/**/*"
+  ]
+}
+


### PR DESCRIPTION
## Problem
TypeScript was still trying to compile test files in CI despite ignore patterns.
The issue is that ts-node's ignore patterns might not be reliable in all scenarios,
especially when TypeScript is doing type checking or resolving imports.

## Solution
Create a dedicated `tsconfig.runtime.json` for runtime TypeScript compilation
that aggressively excludes test files at the configuration level. This is more
reliable than using runtime ignore patterns.

## Changes
- Create `tsconfig.runtime.json` extending `tsconfig.json` with additional exclusions
- Update `src/app/server.js` to use `tsconfig.runtime.json`
- Update `src/core/api-loader.js` to use `tsconfig.runtime.json`
- Remove ignore patterns from ts-node.register() calls (no longer needed)

The new tsconfig.runtime.json excludes:
- `test/**/*` and `**/test/**/*`
- `**/*.test.ts`, `**/*.test.js`, `**/*.spec.ts`, `**/*.spec.js`
- `**/__tests__/**/*` and `**/__test__/**/*`

## Testing
✅ Tests pass locally:
- `test/openapi-mcp-swagger-details.test.js`
- `test/function-handlers.test.js`

This configuration-level exclusion should be more reliable than runtime patterns.