### PR TITLE
fix: Make tsconfig.runtime.json standalone instead of extending

### DIFF
--- a/tsconfig.runtime.json
+++ b/tsconfig.runtime.json
@@ -1,9 +1,18 @@
 {
-  "extends": "./tsconfig.json",
   "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": false,
+    "esModuleInterop": true,
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
-    "noResolve": false
+    "forceConsistentCasingInFileNames": true,
+    "allowJs": true,
+    "checkJs": false,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "types": ["node"]
   },
   "include": [
     "src/**/*",
@@ -13,6 +22,7 @@
   "exclude": [
     "node_modules",
     "**/node_modules/**",
+    "test",
     "test/**/*",
     "**/test/**/*",
     "**/*.test.ts",


### PR DESCRIPTION
## Problem
TypeScript was still trying to compile test files in CI. The issue was that
`tsconfig.runtime.json` was using `extends: './tsconfig.json'`, which might
cause TypeScript to still reference test files through the base configuration.

## Solution
Make `tsconfig.runtime.json` a standalone configuration instead of extending
`tsconfig.json`. This ensures test files are completely excluded without
inheriting any configuration that might include them.

## Changes
- Remove `extends` option from tsconfig.runtime.json
- Copy all compilerOptions directly instead of inheriting
- Add explicit `test` directory exclusion in addition to patterns

## Testing
✅ Tests pass locally:
- `test/openapi-mcp-swagger-details.test.js`
- `test/function-handlers.test.js`

This standalone configuration should completely prevent TypeScript from
compiling test files.