### PR TITLE
fix: Strengthen TypeScript exclusion with additional compiler options

### DIFF
--- a/src/app/server.js
+++ b/src/app/server.js
@@ -2,15 +2,18 @@ require('dotenv').config();
 // Enable TypeScript API loading (compile TS only, ignore JS)
 const path = require('path');
 try {
+  const runtimeConfigPath = path.join(__dirname, '..', 'tsconfig.runtime.json');
   require('ts-node').register({ 
     transpileOnly: true, 
-    project: path.join(__dirname, '..', 'tsconfig.runtime.json'),
+    project: runtimeConfigPath,
     compilerOptions: { 
       allowJs: false, 
       module: 'commonjs', 
       target: 'ES2020',
       skipLibCheck: true,
-      skipDefaultLibCheck: true
+      skipDefaultLibCheck: true,
+      typeRoots: [],
+      types: []
     } 
   });
 } catch (_) { /* optional */ }

--- a/src/core/api-loader.js
+++ b/src/core/api-loader.js
@@ -7,12 +7,16 @@ const fs = require('fs');
 const path = require('path');
 // Ensure TypeScript files can be required when present
 try { 
+  const runtimeConfigPath = path.join(__dirname, '..', 'tsconfig.runtime.json');
   require('ts-node').register({ 
     transpileOnly: true,
-    project: path.join(__dirname, '..', 'tsconfig.runtime.json'),
+    project: runtimeConfigPath,
     compilerOptions: {
       skipLibCheck: true,
-      skipDefaultLibCheck: true
+      skipDefaultLibCheck: true,
+      noResolve: false,
+      typeRoots: [],
+      types: []
     }
   }); 
 } catch (_) { /* optional at runtime/tests */ }

--- a/tsconfig.runtime.json
+++ b/tsconfig.runtime.json
@@ -12,7 +12,9 @@
     "checkJs": false,
     "resolveJsonModule": true,
     "noEmit": true,
-    "types": ["node"]
+    "noResolve": false,
+    "typeRoots": [],
+    "types": []
   },
   "include": [
     "src/**/*",
@@ -30,7 +32,8 @@
     "**/*.spec.ts",
     "**/*.spec.js",
     "**/__tests__/**/*",
-    "**/__test__/**/*"
+    "**/__test__/**/*",
+    "**/.*"
   ]
 }
 


### PR DESCRIPTION
## Problem
TypeScript is still finding and trying to compile test files in CI despite
exclusions. The error shows `tsconfig.json:19:9` which suggests TypeScript
is still encountering test files through type resolution or module resolution.

## Solution
Add more aggressive TypeScript compiler options to prevent test files from
being compiled or type-checked:
- Set `typeRoots: []` to prevent type resolution scanning
- Set `types: []` to prevent @types packages from being loaded
- Add `**/.*` pattern to exclude hidden test directories
- Store runtime config path in variable for clarity

## Changes
- Update `tsconfig.runtime.json` with additional compiler options
- Update `src/app/server.js` to set typeRoots and types to empty
- Update `src/core/api-loader.js` to set typeRoots and types to empty

## Testing
✅ Tests pass locally:
- `test/openapi-mcp-swagger-details.test.js`
- `test/function-handlers.test.js`

This should prevent TypeScript from finding test files through type resolution
or module resolution mechanisms.