### PR TITLE
fix: Add isolatedModules to prevent TypeScript cross-file type resolution

### DIFF
--- a/src/app/server.js
+++ b/src/app/server.js
@@ -11,6 +11,7 @@ try {
   require('ts-node').register({ 
     transpileOnly: true, 
     project: runtimeConfigPath,
+    // Most aggressive settings to prevent type checking
     compilerOptions: { 
       allowJs: false, 
       module: 'commonjs', 
@@ -18,8 +19,16 @@ try {
       skipLibCheck: true,
       skipDefaultLibCheck: true,
       typeRoots: [],
-      types: []
-    }
+      types: [],
+      // Disable type checking entirely
+      checkJs: false,
+      noImplicitAny: false,
+      strict: false,
+      // Prevent TypeScript from resolving types across files
+      isolatedModules: true
+    },
+    // Don't search for tsconfig files automatically - use only what we specify
+    skipProject: false
   });
 } catch (err) { 
   // Log the error for debugging but don't fail

--- a/src/core/api-loader.js
+++ b/src/core/api-loader.js
@@ -7,19 +7,37 @@ const fs = require('fs');
 const path = require('path');
 // Ensure TypeScript files can be required when present
 try { 
-  const runtimeConfigPath = path.join(__dirname, '..', 'tsconfig.runtime.json');
+  const runtimeConfigPath = path.resolve(__dirname, '..', 'tsconfig.runtime.json');
+  // Verify config file exists
+  if (!fs.existsSync(runtimeConfigPath)) {
+    console.warn(`⚠️  tsconfig.runtime.json not found at ${runtimeConfigPath}`);
+  }
   require('ts-node').register({ 
     transpileOnly: true,
     project: runtimeConfigPath,
+    // Most aggressive settings to prevent type checking
     compilerOptions: {
       skipLibCheck: true,
       skipDefaultLibCheck: true,
       noResolve: false,
       typeRoots: [],
-      types: []
-    }
+      types: [],
+      // Disable type checking entirely
+      checkJs: false,
+      noImplicitAny: false,
+      strict: false,
+      // Prevent TypeScript from resolving types across files
+      isolatedModules: true
+    },
+    // Don't search for tsconfig files automatically - use only what we specify
+    skipProject: false
   }); 
-} catch (_) { /* optional at runtime/tests */ }
+} catch (err) { 
+  // Log the error for debugging but don't fail
+  if (process.env.NODE_ENV !== 'test') {
+    console.warn('⚠️  ts-node registration failed:', err.message);
+  }
+}
 const { apiSpecTs } = require('../utils/api/openapi-helper');
 const { apiSpec, queryParam, tsSchema } = require('../utils/api/openapi-helper');
 


### PR DESCRIPTION
Add isolatedModules: true to ts-node compilerOptions to prevent TypeScript from doing cross-file type resolution that might encounter test files. This should prevent TypeScript from scanning test files when compiling legitimate API files.