### PR TITLE
Fix incorrect import paths in test files

### DIFF
--- a/test/base-api-enhanced.test.js
+++ b/test/base-api-enhanced.test.js
@@ -7,7 +7,7 @@ const BaseAPIEnhanced = require('../src/api/base/base-api-enhanced');
 // Mock dependencies
 jest.mock('../src/utils/logger');
 jest.mock('../src/utils/llm/llm-service');
-jest.mock('../src/utils/mcp/resource-loader');
+jest.mock('../src/utils/loaders/resource-loader');
 
 // Mock LLM service
 const { createLLMService } = require('../src/utils/llm/llm-service');

--- a/test/hot-reloader.test.js
+++ b/test/hot-reloader.test.js
@@ -1,4 +1,4 @@
-const HotReloader = require('../src/utils/hot-reloader');
+const HotReloader = require('../src/utils/loaders/hot-reloader');
 const chokidar = require('chokidar');
 const { 
   createMockApiLoader, 


### PR DESCRIPTION
## Summary
- Fixed incorrect module import paths in test files
- Modules were moved to src/utils/loaders/ but tests still referenced old paths
- Resolves "Cannot find module" test suite failures

## Problem
After code reorganization, resource-loader and hot-reloader were moved to `src/utils/loaders/` directory, but test files were still importing from the old locations:
- `../src/utils/mcp/resource-loader` (doesn't exist)
- `../src/utils/hot-reloader` (doesn't exist)

This caused entire test suites to fail before any tests could run.

## Changes Made
**test/base-api-enhanced.test.js**:
```diff
-jest.mock('../src/utils/mcp/resource-loader');
+jest.mock('../src/utils/loaders/resource-loader');
```

**test/hot-reloader.test.js**:
```diff
-const HotReloader = require('../src/utils/hot-reloader');
+const HotReloader = require('../src/utils/loaders/hot-reloader');
```

## Test Results
✅ base-api-enhanced test suite now runs successfully
✅ hot-reloader test suite now runs successfully  
✅ Reduces test suite failures from 9 to 7

## Related
Continues fix series: PRs #370, #371, #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)