### PR TITLE
Improve package.json resolution for test environments

### DIFF
--- a/src/api/openapi/openapi-generator.js
+++ b/src/api/openapi/openapi-generator.js
@@ -288,11 +288,17 @@ class OpenAPIGenerator {
     const fs = require('fs');
 
     // Resolve package.json from the root of the project
+    // Try multiple paths to ensure it works in different environments
     let packageJson = { version: '1.0.0' }; // Default fallback
     try {
-      const packagePath = path.resolve(__dirname, '../../package.json');
+      // Try relative path from this file
+      let packagePath = path.resolve(__dirname, '../../package.json');
+      if (!fs.existsSync(packagePath)) {
+        // Try from process.cwd() for test environments
+        packagePath = path.join(process.cwd(), 'package.json');
+      }
       if (fs.existsSync(packagePath)) {
-        packageJson = require(packagePath);
+        packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
       }
     } catch (error) {
       // Use fallback version if package.json cannot be loaded

--- a/src/mcp/handlers/transport/http-handler.js
+++ b/src/mcp/handlers/transport/http-handler.js
@@ -31,11 +31,17 @@ class HTTPHandler {
     this.processMCPRequest = processMCPRequest;
 
     // Load package.json version
+    // Try multiple paths to ensure it works in different environments
     this.version = '1.0.0'; // Default fallback
     try {
-      const packagePath = path.resolve(__dirname, '../../../package.json');
+      // Try relative path from this file
+      let packagePath = path.resolve(__dirname, '../../../package.json');
+      if (!fs.existsSync(packagePath)) {
+        // Try from process.cwd() for test environments
+        packagePath = path.join(process.cwd(), 'package.json');
+      }
       if (fs.existsSync(packagePath)) {
-        this.version = require(packagePath).version;
+        this.version = JSON.parse(fs.readFileSync(packagePath, 'utf8')).version;
       }
     } catch (error) {
       // Use fallback version if package.json cannot be loaded


### PR DESCRIPTION
Enhanced package.json loading to work in both runtime and Jest test environments. Try multiple resolution paths and use readFileSync to avoid caching. Fixes version test expecting 1.0.111 instead of fallback 1.0.0.