### PR TITLE
Fix tsconfig.runtime.json path resolution in api-loader

### DIFF
--- a/src/utils/loaders/api-loader.js
+++ b/src/utils/loaders/api-loader.js
@@ -24,8 +24,8 @@
 const fs = require('fs');
 const path = require('path');
 // Ensure TypeScript files can be required when present
-try { 
-  const runtimeConfigPath = path.resolve(__dirname, '..', '..', 'tsconfig.runtime.json');
+try {
+  const runtimeConfigPath = path.resolve(__dirname, '..', '..', '..', 'tsconfig.runtime.json');
   // Verify config file exists
   if (!fs.existsSync(runtimeConfigPath)) {
     console.warn(`⚠️  tsconfig.runtime.json not found at ${runtimeConfigPath}`);


### PR DESCRIPTION
## Summary
Fixed incorrect path calculation for tsconfig.runtime.json that was preventing TypeScript API files from being loaded.

## Problem
The api-loader.js was looking for tsconfig.runtime.json at `src/tsconfig.runtime.json` instead of the project root, causing ts-node registration to fail and TypeScript API files not to load.

## Solution
Changed path resolution from 2 levels up to 3 levels up:
- Before: `path.resolve(__dirname, '..', '..', 'tsconfig.runtime.json')` → `src/tsconfig.runtime.json`
- After: `path.resolve(__dirname, '..', '..', '..', 'tsconfig.runtime.json')` → project root

## Impact
This fix is critical for loading the example-project APIs which are written in TypeScript, and should resolve the remaining OpenAPI/MCP test failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)