### PR TITLE
fix: Remove CHANGELOG.md from package.json files field

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "src/",
     "scripts/",
     "README.md",
-    "CHANGELOG.md",
     "types/"
   ],
   "publishConfig": {


### PR DESCRIPTION
## Fix
Remove CHANGELOG.md from package.json files field since it has been merged into README.md.

This will trigger a patch release (1.0.111 → 1.0.112).