### PR TITLE
Add process and port cleanup to start.sh template

### DIFF
--- a/src/easy-mcp-server.js
+++ b/src/easy-mcp-server.js
@@ -402,7 +402,30 @@ module.exports = PostExample;
   const startSh = `#!/bin/bash
 
 # Easy MCP Server Start Script
-# This script loads environment variables and starts the server
+# This script stops existing processes, loads environment variables, and starts the server
+
+# Stop existing easy-mcp-server processes
+echo "🔍 Checking for existing easy-mcp-server processes..."
+PIDS=$(pgrep -f "easy-mcp-server" 2>/dev/null || true)
+
+if [ ! -z "$PIDS" ]; then
+  echo "🛑 Found existing easy-mcp-server processes: $PIDS"
+  echo "   Stopping existing processes..."
+  for PID in $PIDS; do
+    kill -TERM $PID 2>/dev/null || true
+  done
+  sleep 2
+  # Force kill if still running
+  REMAINING=$(pgrep -f "easy-mcp-server" 2>/dev/null || true)
+  if [ ! -z "$REMAINING" ]; then
+    echo "⚠️  Force killing remaining processes..."
+    for PID in $REMAINING; do
+      kill -KILL $PID 2>/dev/null || true
+    done
+    sleep 1
+  fi
+  echo "✅ Existing processes stopped"
+fi
 
 # Load environment variables from .env file
 if [ -f .env ]; then
@@ -413,10 +436,43 @@ if [ -f .env ]; then
   source <(grep -v '^[[:space:]]*#' .env | grep -v '^[[:space:]]*$' | sed 's/[[:space:]]*#.*$//')
   set +a
   echo "📄 Loaded environment variables from .env"
+else
+  echo "⚠️  No .env file found, using default ports"
+  export EASY_MCP_SERVER_PORT=\${EASY_MCP_SERVER_PORT:-8887}
+  export EASY_MCP_SERVER_MCP_PORT=\${EASY_MCP_SERVER_MCP_PORT:-8888}
+fi
+
+# Stop processes using the configured ports
+REST_PORT=\${EASY_MCP_SERVER_PORT:-8887}
+MCP_PORT=\${EASY_MCP_SERVER_MCP_PORT:-8888}
+
+PORT_PIDS=$(lsof -ti :$REST_PORT -ti :$MCP_PORT 2>/dev/null || true)
+if [ ! -z "$PORT_PIDS" ]; then
+  echo "🔍 Found processes using ports $REST_PORT/$MCP_PORT: $PORT_PIDS"
+  echo "   Stopping processes using these ports..."
+  for PID in $PORT_PIDS; do
+    kill -TERM $PID 2>/dev/null || true
+  done
+  sleep 1
+  # Force kill if still running
+  REMAINING_PORTS=$(lsof -ti :$REST_PORT -ti :$MCP_PORT 2>/dev/null || true)
+  if [ ! -z "$REMAINING_PORTS" ]; then
+    echo "⚠️  Force killing remaining processes on ports..."
+    for PID in $REMAINING_PORTS; do
+      kill -KILL $PID 2>/dev/null || true
+    done
+    sleep 1
+  fi
+  echo "✅ Port processes cleared"
 fi
 
 # Start the server
 echo "🚀 Starting Easy MCP Server..."
+echo "📡 Server will be available at:"
+echo "   🌐 REST API: http://localhost:$REST_PORT"
+echo "   🤖 AI Server: http://localhost:$MCP_PORT"
+echo "   📚 API Docs: http://localhost:$REST_PORT/docs"
+echo ""
 npx easy-mcp-server
 
 # Keep the script running if server exits


### PR DESCRIPTION
This PR enhances the generated `start.sh` script to stop existing processes before starting the server.

**Changes:**
- Stop existing easy-mcp-server processes (by process name) before starting
- Stop processes using configured ports (REST and MCP ports) 
- Gracefully handles both TERM and KILL signals for cleanup
- Display server URLs before starting for better UX
- Maintains backward compatibility with existing functionality

**Benefits:**
- Prevents port conflicts when restarting servers
- Ensures only one instance runs at a time
- Clean server restarts without manual cleanup needed
- Better user experience with informative messages

**Testing:**
- All init-command tests pass (18/18)
- Verified template literal escaping for bash syntax