### PR TITLE
feat: Enable minor releases and upgrade to v1.1.0

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -5,9 +5,9 @@
       "preset": "angular",
       "releaseRules": [
         {"type": "major", "release": false},
-        {"type": "minor", "release": false},
+        {"type": "minor", "release": "minor"},
         {"type": "patch", "release": "patch"},
-        {"type": "feat", "release": "patch"},
+        {"type": "feat", "release": "minor"},
         {"type": "fix", "release": "patch"},
         {"type": "docs", "release": "patch"},
         {"type": "style", "release": "patch"},


### PR DESCRIPTION
This PR updates the semantic-release configuration to enable minor version releases for feature commits and triggers a minor release to upgrade from 1.0.111 to 1.1.0.

## Changes
- Update  to allow minor releases for `feat:` commits
- Change `feat` release type from `patch` to `minor`
- Enable `minor` type releases

## Version Bump
- Current: 1.0.111
- Target: 1.1.0

## Semantic Versioning
- **feat:** commits → minor releases (1.0.x → 1.1.0)
- **fix:** commits → patch releases (1.0.x → 1.0.x+1)

This follows standard semantic versioning conventions where new features increment the minor version number.