### PR TITLE
docs: Emphasize MCP as primary goal in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@ npm install
 ./start.sh
 ```
 
-**That's it!** Your API is running at **http://localhost:8887** 🎉
+**That's it!** Your **MCP server** is running at **http://localhost:8888** 🤖
+
+Plus, you get:
+- **REST API** at http://localhost:8887
+- **Swagger UI** at http://localhost:8887/docs
+- **OpenAPI spec** at http://localhost:8887/openapi.json
 
 ### 2. Write Your First Endpoint
 
@@ -61,11 +66,11 @@ module.exports = handler;
 ```
 
 **What you get:**
+- ✅ **MCP Server** - Your API endpoints automatically become MCP tools for AI agents 🤖
+- ✅ **MCP Bridge** - Connect to external MCP servers (included by default: Chrome MCP for browser automation & iTerm MCP for system operations)
 - ✅ REST API endpoints (automatic from file structure)
 - ✅ Swagger UI at `/docs` (auto-generated)
 - ✅ OpenAPI spec at `/openapi.json` (auto-generated)
-- ✅ MCP tools for AI agents (automatic)
-- ✅ **MCP Bridge** - Connect to external MCP servers (included by default: Chrome MCP for browser automation & iTerm MCP for system operations)
 - ✅ Hot reload enabled (save and see changes instantly)
 
 
@@ -84,10 +89,10 @@ api/products/[id]/get.js  → GET /products/:id
 - Request/Response classes → Auto-generated schemas
 
 **Result:**
+- 🤖 **MCP Server** - AI agents can use your endpoints as tools
 - 🚀 REST API endpoints
 - 📚 Swagger UI documentation
 - 📄 OpenAPI specification
-- 🤖 MCP tools for AI agents
 
 ---
 
@@ -152,10 +157,10 @@ After starting, access:
 
 | Service | URL |
 |---------|-----|
+| **MCP Server** 🤖 | http://localhost:8888 |
 | **REST API** | http://localhost:8887 |
 | **Swagger UI** | http://localhost:8887/docs |
 | **OpenAPI Spec** | http://localhost:8887/openapi.json |
-| **MCP Server** | http://localhost:8888 |
 
 ---
 


### PR DESCRIPTION
Update the README Quick Start section to emphasize MCP (Model Context Protocol) as the primary goal of the project.

## Changes
- Quick Start now highlights MCP server (http://localhost:8888) as the main feature
- MCP Server listed first in all feature sections
- MCP Server first in Service Endpoints table
- REST API and other features shown as additional benefits

## Before
- Quick Start said: "Your API is running at http://localhost:8887"
- MCP was mentioned but not emphasized

## After
- Quick Start says: "Your MCP server is running at http://localhost:8888"
- MCP Server is the primary feature, REST API is secondary
- Better alignment with project goals

This change makes it clear that MCP integration is the major goal, with REST API and other features as valuable additions.