### PR TITLE
config: Configure semantic-release for patch-only releases

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -4,10 +4,10 @@
     ["@semantic-release/commit-analyzer", {
       "preset": "angular",
       "releaseRules": [
-        {"type": "major", "release": false},
-        {"type": "minor", "release": "minor"},
+        {"type": "major", "release": "patch"},
+        {"type": "minor", "release": "patch"},
         {"type": "patch", "release": "patch"},
-        {"type": "feat", "release": "minor"},
+        {"type": "feat", "release": "patch"},
         {"type": "fix", "release": "patch"},
         {"type": "docs", "release": "patch"},
         {"type": "style", "release": "patch"},


### PR DESCRIPTION
Update semantic-release configuration to only perform patch releases, regardless of commit type.

## Changes
- All commit types now trigger patch releases
-  commits → patch release (was minor)
-  commits → patch release
- All other commits → patch release
- Major and minor commit types → patch release

## Version Bump Behavior
- **Before**: feat commits triggered minor releases (1.1.0 → 1.2.0)
- **After**: All commits trigger patch releases (1.1.0 → 1.1.1, 1.1.1 → 1.1.2, etc.)

## Rationale
This ensures consistent patch-level versioning going forward, maintaining backward compatibility and avoiding unnecessary major version changes.