### PR TITLE
fix: Correct module paths after CLI refactoring

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -6,9 +6,9 @@
 require('dotenv').config();
 // Enable TypeScript API loading (compile TS only, ignore JS)
 const path = require('path');
+const fs = require('fs');
 try {
   const runtimeConfigPath = path.resolve(__dirname, '..', 'tsconfig.runtime.json');
-  const fs = require('fs');
   const configExists = fs.existsSync(runtimeConfigPath);
   
   // Compiler options to use (either from file or inline)

--- a/src/utils/cli/server-start.js
+++ b/src/utils/cli/server-start.js
@@ -73,7 +73,7 @@ async function startAutoServer(portConfig) {
     
     // Set up environment variables for the server
     const originalCwd = process.cwd();
-    const mainProjectPath = path.join(__dirname, '..', '..');
+    const mainProjectPath = path.join(__dirname, '..', '..', '..');
     
     // Configure environment variables
     process.env.EASY_MCP_SERVER_API_PATH = path.join(originalCwd, 'api');

--- a/src/utils/cli/utils.js
+++ b/src/utils/cli/utils.js
@@ -38,7 +38,7 @@ let envHotReloader = null;
  */
 function initializeEnvHotReloader() {
   try {
-    const EnvHotReloader = require('../utils/loaders/env-hot-reloader');
+    const EnvHotReloader = require('../loaders/env-hot-reloader');
     envHotReloader = new EnvHotReloader({
       debounceDelay: 1000,
       onReload: () => {


### PR DESCRIPTION
Fix incorrect module paths that were introduced when CLI modules were moved to `utils/cli/` directory.

## Changes
- **server-start.js**: Fix `mainProjectPath` - was `'..', '..'`, now `'..', '..', '..'`
- **utils.js**: Fix `EnvHotReloader` require path - was `'../utils/loaders/env-hot-reloader'`, now `'../loaders/env-hot-reloader'`
- **orchestrator.js**: Move `fs` require to top of file (minor refactoring)

## Problem
After moving CLI modules from `src/cli/` to `src/utils/cli/`, some relative paths were not updated correctly, causing potential module loading issues.

## Solution
Updated all relative paths to match the new directory structure.