### PR TITLE
fix: Correct path calculation for public directory fallback

### DIFF
--- a/src/utils/cli/server-start.js
+++ b/src/utils/cli/server-start.js
@@ -73,8 +73,11 @@ async function startAutoServer(portConfig) {
     
     // Set up environment variables for the server
     const originalCwd = process.cwd();
-    // Resolve package root: from src/utils/cli/ go up to package root (2 levels up)
-    const mainProjectPath = path.join(__dirname, '..', '..');
+    // Resolve paths:
+    // - packageRoot: from src/utils/cli/ go up 3 levels to package root
+    // - srcPath: from src/utils/cli/ go up 2 levels to src directory
+    const packageRoot = path.join(__dirname, '..', '..', '..');
+    const srcPath = path.join(__dirname, '..', '..');
 
     // Configure environment variables
     process.env.EASY_MCP_SERVER_API_PATH = path.join(originalCwd, 'api');
@@ -87,18 +90,18 @@ async function startAutoServer(portConfig) {
       console.log(`🔌 Auto-detected MCP bridge config: ${bridgeConfigPath}`);
     }
 
-    // Configure static directory
+    // Configure static directory - use package root for fallback public directory
     const publicDir = path.join(originalCwd, 'public');
     process.env.EASY_MCP_SERVER_STATIC_DIRECTORY = fs.existsSync(publicDir)
       ? publicDir
-      : (process.env.EASY_MCP_SERVER_STATIC_DIRECTORY || path.join(mainProjectPath, 'public'));
+      : (process.env.EASY_MCP_SERVER_STATIC_DIRECTORY || path.join(packageRoot, 'public'));
 
     // Set ports
     process.env.EASY_MCP_SERVER_PORT = portConfig.port.toString();
     process.env.EASY_MCP_SERVER_MCP_PORT = portConfig.mcpPort.toString();
 
-    // Import and start the orchestrator (it's in the same src directory)
-    const orchestratorPath = path.join(mainProjectPath, 'orchestrator.js');
+    // Import and start the orchestrator (it's in the src directory)
+    const orchestratorPath = path.join(srcPath, 'orchestrator.js');
     const orchestrator = require(orchestratorPath);
     
     // The orchestrator should start automatically when required


### PR DESCRIPTION
Fix bug where `mainProjectPath` was incorrectly pointing to `src/` directory instead of package root.

## Bug
The path calculation for `mainProjectPath` was changed to `'..', '..'` (pointing to `src/`), which worked for finding `orchestrator.js` but broke the fallback public directory lookup. When a user doesn't have a `public/` directory in their project, the code incorrectly looked for `src/public/` instead of the actual fallback at the package root's `public/` directory.

## Fix
- Split path resolution into two separate variables:
  - `packageRoot` = `'..', '..', '..'` → points to package root (for `public/` fallback)
  - `srcPath` = `'..', '..'` → points to `src/` directory (for `orchestrator.js`)
- Line 97: Public directory fallback now correctly uses `packageRoot`
- Line 104: Orchestrator path still works correctly using `srcPath`

## Verification
- ✅ `orchestratorPath` = `src/orchestrator.js` (correct)
- ✅ `public fallback` = `public/` at package root (fixed)