### PR TITLE
fix: Update test expectations for package.json scripts

### DIFF
--- a/test/init-command.test.js
+++ b/test/init-command.test.js
@@ -102,9 +102,13 @@ describe('easy-mcp-server init command', () => {
     expect(packageJson.version).toBe('1.0.0');
     expect(packageJson.main).toBe('index.js');
     expect(packageJson.scripts).toBeDefined();
-    expect(packageJson.scripts.start).toBe('easy-mcp-server');
+    expect(packageJson.scripts.start).toBe('./start.sh');
     expect(packageJson.scripts.dev).toBe('easy-mcp-server');
     expect(packageJson.scripts.test).toBe('jest');
+    expect(packageJson.scripts.build).toBe('./build.sh');
+    expect(packageJson.scripts.stop).toBe('./stop.sh');
+    expect(packageJson.scripts['start:direct']).toBe('easy-mcp-server');
+    expect(packageJson.scripts['start:npx']).toBe('npx easy-mcp-server');
     expect(packageJson.dependencies).toBeDefined();
     expect(packageJson.dependencies['easy-mcp-server']).toBeDefined();
   });


### PR DESCRIPTION
## Summary
- Fixed test expectations in `init-command.test.js` to match the updated package.json template
- The package.json template was recently updated to use shell scripts (`./start.sh`, `./build.sh`, `./stop.sh`) instead of direct commands
- Added additional test validations for the new script commands: `build`, `stop`, `start:direct`, and `start:npx`

## Test plan
- [x] Verified test passes locally
- [ ] Wait for GitHub Actions to confirm all tests pass

## Related Issue
Fixes the failing GitHub Action that was introduced in PR #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)