### PR TITLE
fix: Update easy-mcp-server dependency version in init template

### DIFF
--- a/src/utils/cli/init-project.js
+++ b/src/utils/cli/init-project.js
@@ -59,7 +59,7 @@ function createPackageJson(projectDir, projectName) {
       'start:npx': 'npx easy-mcp-server'
     },
     dependencies: {
-      'easy-mcp-server': '^1.0.93',
+      'easy-mcp-server': '^1.1.5',
       'express': '^4.18.2',
       'cors': '^2.8.5',
       'dotenv': '^16.3.1'


### PR DESCRIPTION
## Summary
- Updated the easy-mcp-server dependency in the init project template from `^1.0.93` to `^1.1.5`
- Ensures new projects use the latest version with critical bug fixes

## Problem
When users ran `easy-mcp-server init` to create a new project, the generated package.json specified `easy-mcp-server: "^1.0.93"`. When they then ran `npm install`, this would install an older version (1.0.93 or similar) that had critical bugs:

1. **Orchestrator path resolution bug**: The old version looked for `/src/src/orchestrator.js` (double `/src/`) causing "Cannot find module" errors
2. **env-hot-reloader resolution bug**: The old version had incorrect relative paths for the env-hot-reloader module

When the start script ran `npx easy-mcp-server`, it would use the locally installed (buggy) version instead of the globally installed (fixed) version.

## Solution
Updated the template to specify `^1.1.5`, which includes all the path resolution fixes from PRs #397, #398, #399, and #400.

## Test Plan
- [x] Created a test project using the updated template
- [x] Verified package.json has the correct version
- [x] Ran `npm install` and confirmed it installs v1.1.5+
- [x] Started the server with `npx easy-mcp-server` - no errors!
- [ ] Wait for GitHub Actions to confirm all tests pass

## Impact
This will fix the runtime errors that users experience when creating new projects with `easy-mcp-server init`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)