### PR TITLE
chore: add CODEOWNERS for Boqiang Liang

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code owners for this repository
+# Primary owner: Boqiang Liang <boqiang.liang@easynet.world>
+
+# Global default owner for all files
+* boqiang.liang@easynet.world
+
+


### PR DESCRIPTION
Add CODEOWNERS to assign Boqiang Liang <boqiang.liang@easynet.world> as the default owner for all files.