### PR TITLE
docs: update README header - remove title and subtitle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-# easy-mcp-server
-
 <p align="center">
   <img src="images/easy-mcp-server.jpg" alt="easy-mcp-server logo" width="100%">
 </p>
-
-<h2>The easiest way to build MCP</h2>
 
 [![npm version](https://img.shields.io/npm/v/easy-mcp-server.svg)](https://www.npmjs.com/package/easy-mcp-server)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
Update README header for cleaner layout by removing the main title and subtitle, letting the logo banner be the primary visual element.