### PR TITLE
docs: add OpenAPI spec URL to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Your services are now running at:
 - MCP Server: http://localhost:8888
 - REST API: http://localhost:8887
 - Swagger UI: http://localhost:8887/docs
+- OpenAPI Spec: http://localhost:8887/openapi.json
 
 ### Write Your First Endpoint
 


### PR DESCRIPTION
## Summary

Added OpenAPI specification URL to the Quick Start section for better discoverability.

## Changes

- Added `http://localhost:8887/openapi.json` to the services list

## Why

Users should know where to access the OpenAPI specification file directly, not just through the Swagger UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)