### PR TITLE
Fix: Restore deprecated wrapper methods for backward compatibility

### DIFF
--- a/src/mcp/mcp-server.js
+++ b/src/mcp/mcp-server.js
@@ -371,9 +371,104 @@ class DynamicAPIMCPServer {
     return this.lifecycleManager.createWebSocketServer();
   }
 
-  // Deprecated HTTP handler methods removed - use httpHandler directly
+  /**
+   * @deprecated Use this.mcpRequestProcessor.processMCPRequest() instead
+   */
+  async processMCPRequest(data) {
+    // Lazy initialization if not already initialized
+    if (!this.mcpRequestProcessor) {
+      const MCPRequestProcessor = require('./processors/mcp-request-processor');
+      this.mcpRequestProcessor = new MCPRequestProcessor(this, {
+        toolBuilder: this.toolBuilder,
+        toolExecutor: this.toolExecutor,
+        promptHandler: this.promptHandler,
+        resourceHandler: this.resourceHandler,
+        schemaNormalizer: this.schemaNormalizer,
+        getLoadedRoutes: this.getLoadedRoutes.bind(this),
+        trackRequest: this.trackRequest.bind(this),
+        handleError: this.handleError.bind(this)
+      });
+    }
+    return this.mcpRequestProcessor.processMCPRequest(data);
+  }
 
-  // Deprecated request processing methods removed - use mcpRequestProcessor directly
+  /**
+   * @deprecated Use this.mcpRequestProcessor.processMCPRequest() instead
+   */
+  async processListTools(data) {
+    return this.processMCPRequest({ ...data, method: 'tools/list' });
+  }
+
+  /**
+   * @deprecated Use this.mcpRequestProcessor.processMCPRequest() instead
+   */
+  async processCallTool(data) {
+    return this.processMCPRequest({ ...data, method: 'tools/call' });
+  }
+
+  /**
+   * @deprecated Use this.mcpRequestProcessor.processMCPRequest() instead
+   */
+  async processListPrompts(data) {
+    return this.processMCPRequest({ ...data, method: 'prompts/list' });
+  }
+
+  /**
+   * @deprecated Use this.mcpRequestProcessor.processMCPRequest() instead
+   */
+  async processGetPrompt(data) {
+    return this.processMCPRequest({ ...data, method: 'prompts/get' });
+  }
+
+  /**
+   * @deprecated Use this.mcpRequestProcessor.processMCPRequest() instead
+   */
+  async processListResources(data) {
+    return this.processMCPRequest({ ...data, method: 'resources/list' });
+  }
+
+  /**
+   * @deprecated Use this.mcpRequestProcessor.processMCPRequest() instead
+   */
+  async processReadResource(data) {
+    return this.processMCPRequest({ ...data, method: 'resources/read' });
+  }
+
+  /**
+   * @deprecated Use this.toolExecutor.executeAPIEndpoint() instead
+   */
+  async executeAPIEndpoint(route, args) {
+    return this.toolExecutor.executeAPIEndpoint(route, args, {
+      schemaNormalizer: this.schemaNormalizer
+    });
+  }
+
+  /**
+   * @deprecated Use this.httpHandler.handleSSEConnection() instead
+   */
+  handleSSEConnection(req, res) {
+    if (!this.httpHandler) return;
+    return this.httpHandler.handleSSEConnection(req, res, {
+      httpClients: this.httpClients,
+      cacheManager: this.cacheManager
+    });
+  }
+
+  /**
+   * @deprecated Use this.httpHandler.handleHTTPMCPRequest() instead
+   */
+  handleHTTPMCPRequest(req, res) {
+    if (!this.httpHandler) return;
+    return this.httpHandler.handleHTTPMCPRequest(req, res);
+  }
+
+  /**
+   * @deprecated Use this.httpHandler.handleStreamableHttpRequest() instead
+   */
+  handleStreamableHttpRequest(req, res) {
+    if (!this.httpHandler) return;
+    return this.httpHandler.handleStreamableHttpRequest(req, res);
+  }
 
   /**
    * Notify clients about route changes


### PR DESCRIPTION
## Problem
GitHub Actions tests were failing because deprecated wrapper methods were removed too aggressively during refactoring.

## Solution
- Restored deprecated wrapper methods that delegate to new modular components
- Maintains backward compatibility with existing tests
- All methods are marked as @deprecated with guidance to use new components

## Changes
- Restore `processMCPRequest`, `processListTools`, `processCallTool`, etc.
- Restore `executeAPIEndpoint` for tests
- Restore HTTP handler methods (`handleSSEConnection`, etc.)
- All methods delegate to appropriate handlers/processors

## Result
- File size: 497 lines (78% reduction from original 2,225 lines)
- All tests should now pass
- Backward compatibility maintained

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores deprecated wrapper methods in `src/mcp/mcp-server.js` that delegate to modular processors/handlers, including lazy-initialized MCP request processing and HTTP handler proxies.
> 
> - **Server (`src/mcp/mcp-server.js`)**:
>   - **Deprecated MCP request wrappers restored**: `processMCPRequest`, `processListTools`, `processCallTool`, `processListPrompts`, `processGetPrompt`, `processListResources`, `processReadResource` → delegate to `mcpRequestProcessor` (lazy-initialized).
>   - **HTTP handler proxies restored**: `handleSSEConnection`, `handleHTTPMCPRequest`, `handleStreamableHttpRequest` → forward to `httpHandler`.
>   - **Execution wrapper restored**: `executeAPIEndpoint` → delegates to `toolExecutor.executeAPIEndpoint()` with `schemaNormalizer`.
>   - Maintains existing lifecycle/notification methods; no other files changed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 250c76fbb8798b288a770243bfbf35148f354fc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->