### PR TITLE
Fix: Add getMimeTypeForExtension method

### DIFF
--- a/src/mcp/mcp-server.js
+++ b/src/mcp/mcp-server.js
@@ -440,6 +440,13 @@ class DynamicAPIMCPServer {
   }
 
   /**
+   * @deprecated Use this.resourceHandler.getMimeTypeForExtension() instead
+   */
+  getMimeTypeForExtension(ext) {
+    return this.resourceHandler.getMimeTypeForExtension(ext);
+  }
+
+  /**
    * @deprecated Use this.toolExecutor.executeAPIEndpoint() instead
    */
   async executeAPIEndpoint(route, args) {


### PR DESCRIPTION
## Problem
Test was failing: `server.getMimeTypeForExtension is not a function`

## Solution
- Added `getMimeTypeForExtension` deprecated wrapper method
- Delegates to `this.resourceHandler.getMimeTypeForExtension()`
- All tests now passing locally (775 passed, 6 skipped)

## Result
- All GitHub Actions tests should now pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a deprecated server method `getMimeTypeForExtension` that delegates to `resourceHandler.getMimeTypeForExtension` for MIME lookups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1376944f57065145e8ce9be9af3b28d8d0f6820. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->