### PR TITLE
Feat: Support local MCP server projects in bridge config

### DIFF
--- a/src/mcp/utils/mcp-bridge.js
+++ b/src/mcp/utils/mcp-bridge.js
@@ -31,6 +31,7 @@ class MCPBridge extends EventEmitter {
     this.args = Array.isArray(options.args) ? options.args : [];
     this.proc = null;
     this.env = options.env && typeof options.env === 'object' ? options.env : null;
+    this.cwd = options.cwd || null; // Support working directory for local projects
     this.nextId = 1;
     this.pending = new Map(); // id -> { resolve, reject }
     this.initialized = false;
@@ -47,10 +48,14 @@ class MCPBridge extends EventEmitter {
     if (!this.command) throw new Error('MCPBridge requires a command');
     if (this.proc) return;
     const spawnEnv = this.env ? { ...process.env, ...this.env } : process.env;
-    this.proc = spawn(this.command, this.args, {
+    const spawnOptions = {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: spawnEnv
-    });
+    };
+    if (this.cwd) {
+      spawnOptions.cwd = this.cwd;
+    }
+    this.proc = spawn(this.command, this.args, spawnOptions);
 
     this.proc.stdout.on('data', (chunk) => this._onData(chunk));
     this.proc.stderr.on('data', (chunk) => {


### PR DESCRIPTION
## Problem
Users who create local projects with `easy-mcp-server init project-name` cannot easily use them as MCP bridges. The current config tries to run them as npm packages with `npx -y project-name`, which fails.

## Solution
- **Add `cwd` option**: Support working directory in mcp-bridge.json for local projects
- **Detect local projects**: Automatically detect local projects and provide helpful error messages
- **Support `disabled` flag**: Allow temporarily disabling bridges without removing from config
- **Better error messages**: Provide specific configuration examples when local projects are detected

## Changes
- Added `cwd` support in MCPBridge class
- Updated `resolveAllServers` to extract `cwd` and `disabled` fields
- Improved error detection to identify local projects
- Check multiple possible locations (sibling, subdirectory, cwd)
- Provide configuration examples in error messages

## Usage Example
```json
{
  "mcpServers": {
    "test1": {
      "command": "npx",
      "args": ["easy-mcp-server"],
      "cwd": "../test1"
    }
  }
}
```

## Result
- Local projects can now be used as MCP bridges
- Clear error messages guide users to correct configuration
- Better developer experience