### PR TITLE
Fix: Improve error message for local MCP projects

### DIFF
--- a/src/utils/loaders/mcp-bridge-reloader.js
+++ b/src/utils/loaders/mcp-bridge-reloader.js
@@ -288,15 +288,23 @@ class MCPBridgeReloader {
                     this.logger.warn(`   💡 This appears to be a local project created with 'easy-mcp-server init ${packageName}'`);
                     this.logger.warn(`   Found at: ${localProjectPath}`);
                     this.logger.warn(`   To use it as a bridge, update mcp-bridge.json:`);
-                    this.logger.warn(`   "test1": {`);
+                    this.logger.warn(`   "${name}": {`);
                     this.logger.warn(`     "command": "npx",`);
                     this.logger.warn(`     "args": ["easy-mcp-server"],`);
-                    this.logger.warn(`     "cwd": "${relativePath.startsWith('..') ? relativePath : '../' + relativePath}"`);
+                    this.logger.warn(`     "cwd": "${relativePath.startsWith('..') ? relativePath : '../' + relativePath}",`);
+                    this.logger.warn(`     "env": {`);
+                    this.logger.warn(`       "EASY_MCP_SERVER_STDIO_MODE": "true"`);
+                    this.logger.warn(`     }`);
                     this.logger.warn(`   }`);
-                    this.logger.warn(`   Or use the absolute path: "${localProjectPath}"`);
+                    this.logger.warn(`   Note: MCP bridges require STDIO mode. The env variable is required.`);
                   } else {
-                    this.logger.warn(`   💡 If this is a local project, use a path-based command instead of npx.`);
-                    this.logger.warn(`   Example: { "command": "npx", "args": ["easy-mcp-server"], "cwd": "../${packageName}" }`);
+                    this.logger.warn(`   💡 If this is a local project, use a path-based command with STDIO mode:`);
+                    this.logger.warn(`   Example: {`);
+                    this.logger.warn(`     "command": "npx",`);
+                    this.logger.warn(`     "args": ["easy-mcp-server"],`);
+                    this.logger.warn(`     "cwd": "../${packageName}",`);
+                    this.logger.warn(`     "env": { "EASY_MCP_SERVER_STDIO_MODE": "true" }`);
+                    this.logger.warn(`   }`);
                   }
                 }
                 


### PR DESCRIPTION
## Problem
Error message for local projects didn't include the required STDIO mode configuration.

## Solution
- Add `EASY_MCP_SERVER_STDIO_MODE=true` to example configuration
- Use actual bridge name instead of hardcoded 'test1'
- Clarify that STDIO mode is required for MCP bridges

## Result
Users get complete, correct configuration examples when local projects are detected.