### PR TITLE
fix: Syntax error in orchestrator.js - missing closing brace

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -479,13 +479,13 @@ async function startServer() {
             onReload: () => {
               console.log('🔄 Environment variables reloaded - MCP server will use latest configuration');
             },
-          logger: console,
-          mcpServer: mcpServer,
-          apiLoader: apiLoader,
-          bridgeReloader: bridgeReloader
-        });
-        envHotReloader.startWatching();
-        
+            logger: console,
+            mcpServer: mcpServer,
+            apiLoader: apiLoader,
+            bridgeReloader: bridgeReloader
+          });
+          envHotReloader.startWatching();
+        }
       }).catch(error => {
         console.warn('⚠️  MCP Server failed to start:', error.message);
       });


### PR DESCRIPTION
## Problem
Syntax error in `orchestrator.js` at line 489: 'Unexpected token )'

## Root Cause
When adding STDIO mode checks, a closing brace was missing for the `if (!isStdioMode)` block around the envHotReloader initialization.

## Solution
- Added missing closing brace for the if block
- Fixed indentation for logger property

## Testing
- Syntax check passes
- Test suite runs successfully