### PR TITLE
fix: Suppress all console output in STDIO mode for MCP bridges

### DIFF
--- a/src/api/api-server.js
+++ b/src/api/api-server.js
@@ -134,15 +134,21 @@ class DynamicAPIServer {
         dynamicStatic.dir = null;
         return;
       }
+      const isStdioMode = process.env.EASY_MCP_SERVER_STDIO_MODE === 'true';
+      
       if (dynamicStatic.dir !== absDir) {
-        console.log(`📁 Static files enabled: serving from ${absDir}`);
+        if (!isStdioMode) {
+          console.log(`📁 Static files enabled: serving from ${absDir}`);
+        }
         dynamicStatic.handler = express.static(absDir, {
           index: false,
           dotfiles: 'ignore',
           etag: true,
           lastModified: true
         });
-        console.log('✅ Static file middleware applied successfully');
+        if (!isStdioMode) {
+          console.log('✅ Static file middleware applied successfully');
+        }
         dynamicStatic.dir = absDir;
         dynamicStatic.indexMountedFor = null;
       }
@@ -153,7 +159,9 @@ class DynamicAPIServer {
           this.app.get('/', (req, res) => {
             res.sendFile(indexPath);
           });
-          console.log(`🏠 Root route configured: serving ${this.defaultFile}`);
+          if (!isStdioMode) {
+            console.log(`🏠 Root route configured: serving ${this.defaultFile}`);
+          }
         }
         dynamicStatic.indexMountedFor = dynamicStatic.dir;
       }
@@ -373,10 +381,14 @@ class DynamicAPIServer {
         // Ensure APIs are loaded before starting the server
         this.ensureApisLoaded();
         
+        const isStdioMode = process.env.EASY_MCP_SERVER_STDIO_MODE === 'true';
+        
         this.server = this.app.listen(this.port, this.host, { family: 4 }, () => {
-          console.log(`🚀 Easy MCP Server running on ${this.host}:${this.port}`);
-          console.log(`📚 API Documentation: http://localhost:${this.port}/docs`);
-          console.log(`🔍 Health Check: http://localhost:${this.port}/health`);
+          if (!isStdioMode) {
+            console.log(`🚀 Easy MCP Server running on ${this.host}:${this.port}`);
+            console.log(`📚 API Documentation: http://localhost:${this.port}/docs`);
+            console.log(`🔍 Health Check: http://localhost:${this.port}/health`);
+          }
           resolve();
         });
         

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -494,56 +494,60 @@ async function startServer() {
     }
   }
 
-  // Display server startup information
-  const host = process.env.EASY_MCP_SERVER_HOST || '0.0.0.0';
-  const basePort = parseInt(process.env.EASY_MCP_SERVER_PORT) || 8887;
-  const staticPath = process.env.EASY_MCP_SERVER_STATIC_DIRECTORY || './public';
-  
-  console.log('\n');
-  console.log('  ╔══════════════════════════════════════════════════════════════════════════════════════════════════════╗');
-  console.log('  ║                                                                                                      ║');
-  console.log('  ║                                    🚀 EASY MCP SERVER 🚀                                           ║');
-  console.log('  ║                                                                                                      ║');
-  console.log('  ╚══════════════════════════════════════════════════════════════════════════════════════════════════════╝');
-  console.log('');
-  console.log('  🚀  SERVER STARTED SUCCESSFULLY');
-  console.log('  ' + '═'.repeat(78));
-  console.log(`  📍 Server Address: ${host}:${basePort}`);
-  console.log('  🌍 Environment: development');
-  console.log('');
-  console.log('  📡  API ENDPOINTS:');
-  console.log(`     • Health Check:     http://localhost:${basePort}/health`);
-  console.log(`     • API Information:  http://localhost:${basePort}/api-info`);
-  console.log(`     • MCP Tools:        http://localhost:${basePort}/mcp/tools`);
-  console.log('');
-  console.log('  📚  DOCUMENTATION:');
-  console.log(`     • OpenAPI JSON:     http://localhost:${basePort}/openapi.json`);
-  console.log(`     • Swagger UI:       http://localhost:${basePort}/docs ✨`);
-  console.log(`     • LLM Context:      http://localhost:${basePort}/LLM.txt`);
-  console.log(`     • Agent Context:    http://localhost:${basePort}/Agent.md`);
-  console.log('');
-  if (mcpServer) {
-    console.log('  🤖  MCP SERVER:');
-    console.log(`     • WebSocket:       ws://${mcpServer.host}:${mcpServer.port}`);
-    console.log(`     • Routes Loaded:   ${loadedRoutes.length} API endpoints`);
+  // Display server startup information (skip in STDIO mode)
+  if (!isStdioMode) {
+    const host = process.env.EASY_MCP_SERVER_HOST || '0.0.0.0';
+    const basePort = parseInt(process.env.EASY_MCP_SERVER_PORT) || 8887;
+    const staticPath = process.env.EASY_MCP_SERVER_STATIC_DIRECTORY || './public';
+    
+    console.log('\n');
+    console.log('  ╔══════════════════════════════════════════════════════════════════════════════════════════════════════╗');
+    console.log('  ║                                                                                                      ║');
+    console.log('  ║                                    🚀 EASY MCP SERVER 🚀                                           ║');
+    console.log('  ║                                                                                                      ║');
+    console.log('  ╚══════════════════════════════════════════════════════════════════════════════════════════════════════╝');
+    console.log('');
+    console.log('  🚀  SERVER STARTED SUCCESSFULLY');
+    console.log('  ' + '═'.repeat(78));
+    console.log(`  📍 Server Address: ${host}:${basePort}`);
+    console.log('  🌍 Environment: development');
+    console.log('');
+    console.log('  📡  API ENDPOINTS:');
+    console.log(`     • Health Check:     http://localhost:${basePort}/health`);
+    console.log(`     • API Information:  http://localhost:${basePort}/api-info`);
+    console.log(`     • MCP Tools:        http://localhost:${basePort}/mcp/tools`);
+    console.log('');
+    console.log('  📚  DOCUMENTATION:');
+    console.log(`     • OpenAPI JSON:     http://localhost:${basePort}/openapi.json`);
+    console.log(`     • Swagger UI:       http://localhost:${basePort}/docs ✨`);
+    console.log(`     • LLM Context:      http://localhost:${basePort}/LLM.txt`);
+    console.log(`     • Agent Context:    http://localhost:${basePort}/Agent.md`);
+    console.log('');
+    if (mcpServer) {
+      console.log('  🤖  MCP SERVER:');
+      console.log(`     • WebSocket:       ws://${mcpServer.host}:${mcpServer.port}`);
+      console.log(`     • Routes Loaded:   ${loadedRoutes.length} API endpoints`);
+      console.log('');
+    }
+    console.log('  ⚡  FEATURES:');
+    console.log('     • Auto-discovery of API endpoints');
+    console.log('     • Real-time MCP tool generation');
+    console.log('     • Automatic OpenAPI documentation');
+    console.log('     • Hot reloading enabled');
+    if (fs.existsSync(staticPath)) {
+      console.log('     • Static file serving enabled');
+    }
+    console.log('');
+    console.log('  🎯  Ready to serve your APIs!');
+    console.log('  ' + '═'.repeat(78));
     console.log('');
   }
-  console.log('  ⚡  FEATURES:');
-  console.log('     • Auto-discovery of API endpoints');
-  console.log('     • Real-time MCP tool generation');
-  console.log('     • Automatic OpenAPI documentation');
-  console.log('     • Hot reloading enabled');
-  if (fs.existsSync(staticPath)) {
-    console.log('     • Static file serving enabled');
-  }
-  console.log('');
-  console.log('  🎯  Ready to serve your APIs!');
-  console.log('  ' + '═'.repeat(78));
-  console.log('');
 
   // Graceful shutdown handlers
   const shutdown = async () => {
-    console.log('\n🛑 Shutting down servers...');
+    if (!isStdioMode) {
+      console.log('\n🛑 Shutting down servers...');
+    }
     if (hotReloader) {
       hotReloader.stopWatching();
     }

--- a/src/utils/loaders/api-loader.js
+++ b/src/utils/loaders/api-loader.js
@@ -83,11 +83,16 @@ class APILoader {
    */
   loadAPIs() {
     const apiDir = this.apiPath;
+    const isStdioMode = process.env.EASY_MCP_SERVER_STDIO_MODE === 'true';
     
-    console.log(`🔍 Loading APIs from: ${apiDir}`);
+    if (!isStdioMode) {
+      console.log(`🔍 Loading APIs from: ${apiDir}`);
+    }
     
     if (!fs.existsSync(apiDir)) {
-      console.log(`⚠️  No api/ directory found at: ${apiDir}`);
+      if (!isStdioMode) {
+        console.log(`⚠️  No api/ directory found at: ${apiDir}`);
+      }
       return [];
     }
 
@@ -104,7 +109,7 @@ class APILoader {
     this.scanDirectory(apiDir);
     this.attachProcessorsToRoutes();
     
-    if (this.errors.length > 0) {
+    if (this.errors.length > 0 && !isStdioMode) {
       console.log(`⚠️  ${this.errors.length} API loading errors encountered`);
     }
     
@@ -434,7 +439,10 @@ class APILoader {
         const key = `${httpMethod.toLowerCase()}:${normalizedPath}`;
         this.processors.set(key, instanceForRoute);
 
-        console.log(`✅ Loaded API: ${httpMethod} ${normalizedPath}`);
+        const isStdioMode = process.env.EASY_MCP_SERVER_STDIO_MODE === 'true';
+        if (!isStdioMode) {
+          console.log(`✅ Loaded API: ${httpMethod} ${normalizedPath}`);
+        }
       };
 
       // Case 1: Object export with a process method

--- a/src/utils/loaders/mcp-bridge-reloader.js
+++ b/src/utils/loaders/mcp-bridge-reloader.js
@@ -134,7 +134,10 @@ class MCPBridgeReloader {
     try {
       const raw = fs.readFileSync(cfgPath, 'utf8');
       const config = JSON.parse(raw);
-      this.logger.log(`🔌 Loaded MCP bridge config from ${cfgPath}`);
+      const isStdioMode = process.env.EASY_MCP_SERVER_STDIO_MODE === 'true';
+      if (!isStdioMode) {
+        this.logger.log(`🔌 Loaded MCP bridge config from ${cfgPath}`);
+      }
       return config;
     } catch (e) {
       this.logger.warn(`⚠️  Failed to parse ${cfgPath}: ${e.message}`);


### PR DESCRIPTION
## Problem
Console logs were still being written to stdout in STDIO mode, causing JSON-RPC parsing errors. The previous fix only redirected console.log in server-start.js, but many console.log statements exist in other modules that run before or during server startup.

## Solution
- Suppress console.log in `utils.js` (loadUserEnvFiles, autoInstallDependencies)
- Suppress console.log in `api-loader.js` (Loading APIs, Loaded API messages)
- Suppress console.log in `api-server.js` (Static files, Root route, Server running)
- Suppress console.log in `orchestrator.js` (startup banner, server info)
- Suppress console.log in `mcp-bridge-reloader.js` (bridge config loading)
- Redirect npm install output to stderr in STDIO mode
- Skip env hot reloader initialization in STDIO mode

## Result
- Clean stdout for JSON-RPC communication
- No more parsing errors
- All console output redirected to stderr in STDIO mode