### PR TITLE
fix: Suppress env hot reloader console output in STDIO mode

### DIFF
--- a/src/utils/loaders/env-hot-reloader.js
+++ b/src/utils/loaders/env-hot-reloader.js
@@ -46,14 +46,21 @@ class EnvHotReloader {
    */
   startWatching() {
     if (this.watcher) {
-      this.logger.warn('⚠️  Env hot reloader is already watching');
+      const isStdioMode = process.env.EASY_MCP_SERVER_STDIO_MODE === 'true';
+      if (!isStdioMode) {
+        this.logger.warn('⚠️  Env hot reloader is already watching');
+      }
       return;
     }
+
+    const isStdioMode = process.env.EASY_MCP_SERVER_STDIO_MODE === 'true';
 
     // Create file patterns to watch (always watch for CRUD of these files)
     const watchPatterns = this.envFiles.map(envFile => path.join(this.userCwd, envFile));
 
-    this.logger.log(`🔄 Setting up .env hot reload for: ${this.envFiles.join(', ')}`);
+    if (!isStdioMode) {
+      this.logger.log(`🔄 Setting up .env hot reload for: ${this.envFiles.join(', ')}`);
+    }
 
     // Create watcher
     this.watcher = chokidar.watch(watchPatterns, {
@@ -80,7 +87,9 @@ class EnvHotReloader {
       this.logger.error(`❌ Env watcher error: ${error.message}`);
     });
 
-    this.logger.log('✅ .env hot reload is now active');
+    if (!isStdioMode) {
+      this.logger.log('✅ .env hot reload is now active');
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem
The env hot reloader was still outputting console logs in STDIO mode, causing JSON-RPC parsing errors.

## Solution
- Added STDIO mode check in `env-hot-reloader.js`
- Suppress 'Setting up .env hot reload' message in STDIO mode
- Suppress '.env hot reload is now active' message in STDIO mode

## Result
- Clean stdout for JSON-RPC communication
- No more parsing errors from env hot reloader messages