### PR TITLE
fix: Redirect console output at module load time in STDIO mode

### DIFF
--- a/src/utils/loaders/mcp-bridge-reloader.js
+++ b/src/utils/loaders/mcp-bridge-reloader.js
@@ -253,7 +253,10 @@ class MCPBridgeReloader {
           setTimeout(() => {
             if (bridge.proc && bridge.proc.exitCode === null) {
               this.bridges.set(name, bridge);
-              this.logger.log(`🔌 MCP Bridge started: ${name}`);
+              const isStdioMode = process.env.EASY_MCP_SERVER_STDIO_MODE === 'true';
+              if (!isStdioMode) {
+                this.logger.log(`🔌 MCP Bridge started: ${name}`);
+              }
             } else {
               // Provide better error messages based on the failure type
               if (hasCommandError) {


### PR DESCRIPTION
## Problem
Console output was still appearing on stdout in STDIO mode because the redirection happened too late - after modules were already loaded and executed.

## Solution
- Move console.log/warn redirection to the very top of server-start.js, before any require() statements
- Use process.stderr.write directly instead of console.error to avoid circular issues
- Suppress 'MCP Bridge started' message in STDIO mode
- Ensures all console output is redirected before any modules execute

## Result
- Clean stdout for JSON-RPC communication
- No more parsing errors from console output
- All console output properly redirected to stderr in STDIO mode