### PR TITLE
fix: Move console redirection to entry point for bridge processes

### DIFF
--- a/src/utils/cli/server-start.js
+++ b/src/utils/cli/server-start.js
@@ -3,23 +3,9 @@
  * Handles starting the Easy MCP Server in different modes
  */
 
-// CRITICAL: Redirect console output to stderr in STDIO mode BEFORE any other code runs
-// This must happen before any require() statements to catch all console output
+// Console redirection is now handled at the entry point (easy-mcp-server.js)
+// Check if STDIO mode is enabled for conditional logic
 const isStdioMode = process.env.EASY_MCP_SERVER_STDIO_MODE === 'true';
-if (isStdioMode) {
-  const originalLog = console.log;
-  const originalWarn = console.warn;
-  
-  // Redirect console.log and console.warn to stderr in STDIO mode
-  // This allows stdout to be used exclusively for JSON-RPC messages
-  console.log = (...args) => {
-    process.stderr.write(require('util').format(...args) + '\n');
-  };
-  console.warn = (...args) => {
-    process.stderr.write(require('util').format(...args) + '\n');
-  };
-  // console.error already goes to stderr, so we don't need to redirect it
-}
 
 const fs = require('fs');
 const path = require('path');


### PR DESCRIPTION
## Problem
Console output was still appearing on stdout from bridge processes because the redirection in server-start.js only affected the main process. When bridge processes are spawned via `npx easy-mcp-server`, they start fresh and need their own console redirection.

## Solution
- Move console.log/warn redirection to `easy-mcp-server.js` entry point
- Ensures redirection happens before ANY modules load
- Use simple string formatting instead of util.format to avoid require issues
- Fixes console output in bridge processes spawned via npx easy-mcp-server

## Result
- Clean stdout for JSON-RPC communication in bridge processes
- No more parsing errors from console output
- All console output properly redirected to stderr in STDIO mode